### PR TITLE
feat: Make TrustedHostMiddleware configurable via ALLOWED_HOSTS env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,20 @@ docker run -d --name gitingest -p 8000:8000 gitingest
 ```
 The application will be available at `http://localhost:8000`
 
+### 🌐 Environment Configuration
+
+You can configure the application using the following environment variables:
+
+- **`ALLOWED_HOSTS`**: Specify allowed hostnames for the application. Default: `"gitingest.com,*.gitingest.com,gitdigest.dev,localhost"`.
+
+Example:
+
+```bash
+ALLOWED_HOSTS="gitingest.lan.coronado.io,localhost"
+```
+
+Ensure these variables are set before running the application or deploying it via Docker.
+
 ## ✔️ Contributions are welcome!
 Create a pull request or open an Issue about anything you'd like to see in gitingest
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ You can configure the application using the following environment variables:
 Example:
 
 ```bash
-ALLOWED_HOSTS="gitingest.lan.coronado.io,localhost"
+ALLOWED_HOSTS="gitingest.local,localhost"
 ```
 
 Ensure these variables are set before running the application or deploying it via Docker.

--- a/src/main.py
+++ b/src/main.py
@@ -20,7 +20,18 @@ app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
 app.mount("/static", StaticFiles(directory="static"), name="static")
 app.add_middleware(Analytics, api_key=os.getenv('API_ANALYTICS_KEY'))
-app.add_middleware(TrustedHostMiddleware, allowed_hosts=["gitingest.com", "*.gitingest.com", "gitdigest.dev", "localhost"])
+
+# Define the default allowed hosts
+default_allowed_hosts = ["gitingest.com", "*.gitingest.com", "gitdigest.dev", "localhost"]
+
+# Fetch allowed hosts from the environment variable or use the default
+allowed_hosts = os.getenv("ALLOWED_HOSTS")
+if allowed_hosts:
+    allowed_hosts = allowed_hosts.split(",")
+else:
+    allowed_hosts = default_allowed_hosts
+
+app.add_middleware(TrustedHostMiddleware, allowed_hosts=allowed_hosts)
 templates = Jinja2Templates(directory="templates")
 
 @app.get("/health")


### PR DESCRIPTION
- Added support for configuring allowed hosts dynamically using the ALLOWED_HOSTS environment variable.
- Fallback to a default list of allowed hosts: ["gitingest.com", "*.gitingest.com", "gitdigest.dev", "localhost"]
- Ensures compatibility with custom deployments while maintaining existing defaults.
- Updated src/main.py to implement the changes.
- Updates README.md on usage