### PR TITLE
Add support for github alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 
 [![Image](./docs/frontpage.png)](https://gitingest.com/)
 
-[gitingest.com](https://gitingest.com/) - Turn any GitHub repository into a prompt-friendly text ingest for LLMs.
+[gitingest.com](https://gitingest.com/) - Turn any Git repository into a prompt-friendly text ingest for LLMs.
 You can also replace `hub` with `ingest` in any github url to access the coresponding digest
 
 ## 🚀 Features
 
-- **One-Click Analysis**: Simply paste a GitHub repository URL and get instant pastable context
+- **One-Click Analysis**: Simply paste a Git repository URL and get instant pastable context
 - **Smart Formatting**: Optimized output format for LLM prompts
 - **Statistics about**: :
   - File and directory structure

--- a/src/templates/components/github_form.jinja
+++ b/src/templates/components/github_form.jinja
@@ -8,7 +8,7 @@
             id="ingestForm" onsubmit="handleSubmit(event{% if is_index %}, true{% endif %})">
             <div class="relative w-full h-full">
                 <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0 z-10"></div>
-                <input type="text" name="input_text" id="input_text" placeholder="https://github.com/..., https://gitlab.com/..."
+                <input type="text" name="input_text" id="input_text" placeholder="https://github.com/..."
                     value="{{ github_url if github_url else '' }}"
                     required
                     class="border-[3px] w-full relative z-20 border-gray-900 placeholder-gray-600 text-lg font-medium focus:outline-none py-3.5 px-6 rounded">

--- a/src/templates/components/github_form.jinja
+++ b/src/templates/components/github_form.jinja
@@ -8,7 +8,7 @@
             id="ingestForm" onsubmit="handleSubmit(event{% if is_index %}, true{% endif %})">
             <div class="relative w-full h-full">
                 <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0 z-10"></div>
-                <input type="text" name="input_text" id="input_text" placeholder="https://github.com/..."
+                <input type="text" name="input_text" id="input_text" placeholder="https://github.com/..., https://gitlab.com/..."
                     value="{{ github_url if github_url else '' }}"
                     required
                     class="border-[3px] w-full relative z-20 border-gray-900 placeholder-gray-600 text-lg font-medium focus:outline-none py-3.5 px-6 rounded">

--- a/src/templates/index.jinja
+++ b/src/templates/index.jinja
@@ -38,7 +38,7 @@
         </svg>
     </div>
     <p class="text-gray-600 text-lg max-w-2xl mx-auto text-center mt-8">
-        Turn any GitHub repository into a simple text ingest of its codebase.   
+        Turn any Git repository into a simple text ingest of its codebase.   
     </p>
     <p class="text-gray-600 text-lg max-w-2xl mx-auto text-center mt-0">
         This is useful for feeding a codebase into any LLM.
@@ -60,4 +60,12 @@
 {% endwith %}
 
 {% include 'components/result.jinja' %}
+<p class="text-center mt-4">
+    <span class="bg-gradient-to-r from-pink-500 via-purple-500 to-indigo-500 text-transparent bg-clip-text font-medium">
+        Now supports Gitlab and more ❤️
+    </span>
+</p>
+
+
+
 {% endblock %}

--- a/src/tests/test_parse_query.py
+++ b/src/tests/test_parse_query.py
@@ -2,26 +2,36 @@ import pytest
 from utils.parse_query import parse_query, parse_url
 from config import DEFAULT_IGNORE_PATTERNS
 
+
 def test_parse_url_valid():
-    url = "https://github.com/user/repo"
-    result = parse_url(url)
-    assert result["user_name"] == "user"
-    assert result["repo_name"] == "repo"
-    assert result["url"] == "https://github.com/user/repo"
+    test_cases = [
+        "https://github.com/user/repo",
+        "https://gitlab.com/user/repo", 
+        "https://bitbucket.org/user/repo"
+    ]
+    for url in test_cases:
+        result = parse_url(url)
+        assert result["user_name"] == "user"
+        assert result["repo_name"] == "repo"
+        assert result["url"] == url
 
 def test_parse_url_invalid():
-    url = "https://invalid.com/user/repo"
-    with pytest.raises(ValueError, match="Invalid GitHub URL"):
+    url = "https://only-domain.com"
+    with pytest.raises(ValueError, match="Invalid repository URL"):
         parse_url(url)
 
 def test_parse_query_basic():
-    url = "https://github.com/user/repo"
-    result = parse_query(url, slider_position=50, pattern_type='exclude', pattern='*.txt')
-    assert result["user_name"] == "user"
-    assert result["repo_name"] == "repo"
-    assert result["url"] == "https://github.com/user/repo"
-    assert result["pattern_type"] == "exclude"
-    assert "*.txt" in result["ignore_patterns"]
+    test_cases = [
+        "https://github.com/user/repo",
+        "https://gitlab.com/user/repo"
+    ]
+    for url in test_cases:
+        result = parse_query(url, slider_position=50, pattern_type='exclude', pattern='*.txt')
+        assert result["user_name"] == "user"
+        assert result["repo_name"] == "repo"
+        assert result["url"] == url
+        assert result["pattern_type"] == "exclude"
+        assert "*.txt" in result["ignore_patterns"]
 
 def test_parse_query_include_pattern():
     url = "https://github.com/user/repo"

--- a/src/utils/parse_query.py
+++ b/src/utils/parse_query.py
@@ -35,7 +35,7 @@ def parse_url(url: str) -> dict:
     
     # Keep original URL format
     parsed["url"] = f"https://{domain}/{parsed['user_name']}/{parsed['repo_name']}"
-    parsed['slug'] = f"{domain}-{parsed['user_name']}-{parsed['repo_name']}"
+    parsed['slug'] = f"{parsed['user_name']}-{parsed['repo_name']}"
     parsed["id"] = str(uuid.uuid4())
     parsed["local_path"] = f"{TMP_BASE_PATH}/{parsed['id']}/{parsed['slug']}"
 

--- a/src/utils/parse_query.py
+++ b/src/utils/parse_query.py
@@ -6,13 +6,6 @@ from typing import List
 
 from config import TMP_BASE_PATH, DEFAULT_IGNORE_PATTERNS
 
-def validate_github_url(url: str) -> bool:
-    if not url.startswith('https://'):
-        url = 'https://' + url
-        
-    github_pattern = r'^https://github\.com/[^/]+/[^/]+'
-    return bool(re.match(github_pattern, url))
-
 def parse_url(url: str) -> dict:
     parsed = {
         "user_name": None,
@@ -25,22 +18,26 @@ def parse_url(url: str) -> dict:
         "url": None,
     }
     
-    if not validate_github_url(url):
-        raise ValueError("Invalid GitHub URL. Please provide a valid GitHub repository URL.")
-    
     url = url.split(" ")[0]
-    url = url.replace("https://github.com/", "")
-    path_parts = url.split('/')
-
+    if not url.startswith('https://'):
+        url = 'https://' + url
+        
+    # Extract domain and path
+    url_parts = url.split('/')
+    domain = url_parts[2]
+    path_parts = url_parts[3:]
+    
+    if len(path_parts) < 2:
+        raise ValueError("Invalid repository URL. Please provide a valid Git repository URL.")
+        
     parsed["user_name"] = path_parts[0]
     parsed["repo_name"] = path_parts[1]
     
-
-    parsed["url"] = f"https://github.com/{parsed['user_name']}/{parsed['repo_name']}"
-    parsed['slug'] = parsed["url"].replace("https://github.com/", "").replace("/", "-")
+    # Keep original URL format
+    parsed["url"] = f"https://{domain}/{parsed['user_name']}/{parsed['repo_name']}"
+    parsed['slug'] = f"{domain}-{parsed['user_name']}-{parsed['repo_name']}"
     parsed["id"] = str(uuid.uuid4())
     parsed["local_path"] = f"{TMP_BASE_PATH}/{parsed['id']}/{parsed['slug']}"
-    
 
     if len(path_parts) > 3:
         parsed["type"] = path_parts[2]
@@ -50,7 +47,6 @@ def parse_url(url: str) -> dict:
             
         parsed["subpath"] = "/" + "/".join(path_parts[4:])
     return parsed
-
 
 def normalize_pattern(pattern: str) -> str:
     pattern = pattern.strip()


### PR DESCRIPTION
You can now paste links from other platforms if they follow the same pattern as github: https://xxxxxxx/username/repo.git