### PR TITLE
Place repository root level readme first in file content output

### DIFF
--- a/src/gitingest/ingest_from_query.py
+++ b/src/gitingest/ingest_from_query.py
@@ -219,8 +219,20 @@ def create_file_content_string(files: List[Dict]) -> str:
     output = ""
     separator = "=" * 48 + "\n"
 
+    # First add README.md if it exists
     for file in files:
         if not file['content']:
+            continue
+        if file['path'].lower() == '/readme.md':
+            output += separator
+            output += f"File: {file['path']}\n"
+            output += separator
+            output += f"{file['content']}\n\n"
+            break
+
+    # Then add all other files in their original order
+    for file in files:
+        if not file['content'] or file['path'].lower() == '/readme.md':
             continue
         output += separator
         output += f"File: {file['path']}\n"


### PR DESCRIPTION
Modified `create_file_content_string()` to show root level README.md first in the repository content output file using a two pass approach. This is motivated by the [structure](https://github.com/AnswerDotAI/llms-txt) proposed by AnswerDotAI for llms.txt files.

Ran the test suite and all 11 tests pass.