### PR TITLE
refactor: refactor codebase to use pathlib instead of os.path

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1,7 +1,9 @@
 """ Configuration file for the project. """
 
+from pathlib import Path
+
 MAX_DISPLAY_SIZE: int = 300_000
-TMP_BASE_PATH: str = "/tmp/gitingest"
+TMP_BASE_PATH = Path("/tmp/gitingest")
 DELETE_REPO_AFTER: int = 60 * 60  # In seconds
 
 EXAMPLE_REPOS: list[dict[str, str]] = [

--- a/src/gitingest/ingest.py
+++ b/src/gitingest/ingest.py
@@ -4,6 +4,7 @@ import asyncio
 import inspect
 import shutil
 
+from config import TMP_BASE_PATH
 from gitingest.clone import CloneConfig, clone_repo
 from gitingest.ingest_from_query import ingest_from_query
 from gitingest.parse_query import parse_query
@@ -63,7 +64,7 @@ def ingest(
             # Extract relevant fields for CloneConfig
             clone_config = CloneConfig(
                 url=query["url"],
-                local_path=query["local_path"],
+                local_path=str(query["local_path"]),
                 commit=query.get("commit"),
                 branch=query.get("branch"),
             )
@@ -84,6 +85,5 @@ def ingest(
     finally:
         # Clean up the temporary directory if it was created
         if query["url"]:
-            # Clean up the temporary directory under /tmp/gitingest
-            cleanup_path = "/tmp/gitingest"
-            shutil.rmtree(cleanup_path, ignore_errors=True)
+            # Clean up the temporary directory
+            shutil.rmtree(TMP_BASE_PATH, ignore_errors=True)

--- a/src/process_query.py
+++ b/src/process_query.py
@@ -86,7 +86,7 @@ async def process_query(
         )
         clone_config = CloneConfig(
             url=query["url"],
-            local_path=query["local_path"],
+            local_path=str(query["local_path"]),
             commit=query.get("commit"),
             branch=query.get("branch"),
         )

--- a/src/routers/download.py
+++ b/src/routers/download.py
@@ -1,7 +1,5 @@
 """ This module contains the FastAPI router for downloading a digest file. """
 
-import os
-
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import Response
 
@@ -13,7 +11,7 @@ router = APIRouter()
 @router.get("/download/{digest_id}")
 async def download_ingest(digest_id: str) -> Response:
     """
-    Downloads a .txt file associated with a given digest ID.
+    Download a .txt file associated with a given digest ID.
 
     This function searches for a `.txt` file in a directory corresponding to the provided
     digest ID. If a file is found, it is read and returned as a downloadable attachment.
@@ -37,13 +35,13 @@ async def download_ingest(digest_id: str) -> Response:
     HTTPException
         If the digest directory is not found or if no `.txt` file exists in the directory.
     """
-    directory = f"{TMP_BASE_PATH}/{digest_id}"
+    directory = TMP_BASE_PATH / digest_id
 
     try:
-        if not os.path.exists(directory):
+        if not directory.exists():
             raise FileNotFoundError("Directory not found")
 
-        txt_files = [f for f in os.listdir(directory) if f.endswith(".txt")]
+        txt_files = [f for f in directory.iterdir() if f.suffix == ".txt"]
         if not txt_files:
             raise FileNotFoundError("No .txt file found")
 
@@ -53,11 +51,11 @@ async def download_ingest(digest_id: str) -> Response:
     # Find the first .txt file in the directory
     first_file = txt_files[0]
 
-    with open(f"{directory}/{first_file}", encoding="utf-8") as f:
+    with first_file.open(encoding="utf-8") as f:
         content = f.read()
 
     return Response(
         content=content,
         media_type="text/plain",
-        headers={"Content-Disposition": f"attachment; filename={first_file}"},
+        headers={"Content-Disposition": f"attachment; filename={first_file.name}"},
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ def sample_query() -> dict[str, Any]:
     return {
         "user_name": "test_user",
         "repo_name": "test_repo",
-        "local_path": "/tmp/test_repo",
+        "local_path": Path("/tmp/test_repo").resolve(),
         "subpath": "/",
         "branch": "main",
         "commit": None,

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -7,7 +7,8 @@ from gitingest.ingest_from_query import _extract_files_content, _scan_directory
 
 
 def test_scan_directory(temp_directory: Path, sample_query: dict[str, Any]) -> None:
-    result = _scan_directory(str(temp_directory), query=sample_query)
+    sample_query["local_path"] = temp_directory
+    result = _scan_directory(temp_directory, query=sample_query)
     if result is None:
         assert False, "Result is None"
 
@@ -18,7 +19,8 @@ def test_scan_directory(temp_directory: Path, sample_query: dict[str, Any]) -> N
 
 
 def test_extract_files_content(temp_directory: Path, sample_query: dict[str, Any]) -> None:
-    nodes = _scan_directory(str(temp_directory), query=sample_query)
+    sample_query["local_path"] = temp_directory
+    nodes = _scan_directory(temp_directory, query=sample_query)
     if nodes is None:
         assert False, "Nodes is None"
     files = _extract_files_content(query=sample_query, node=nodes, max_file_size=1_000_000)

--- a/tests/test_parse_query.py
+++ b/tests/test_parse_query.py
@@ -1,5 +1,7 @@
 """ Tests for the parse_query module. """
 
+from pathlib import Path
+
 import pytest
 
 from gitingest.ignore_patterns import DEFAULT_IGNORE_PATTERNS
@@ -119,7 +121,8 @@ def test_parse_query_include_and_ignore_overlap() -> None:
 def test_parse_query_local_path() -> None:
     path = "/home/user/project"
     result = parse_query(path, max_file_size=100, from_web=False)
-    assert result["local_path"] == "/home/user/project"
+    tail = Path("home/user/project")
+    assert result["local_path"].parts[-len(tail.parts) :] == tail.parts
     assert result["id"] is not None
     assert result["slug"] == "user/project"
 
@@ -127,7 +130,8 @@ def test_parse_query_local_path() -> None:
 def test_parse_query_relative_path() -> None:
     path = "./project"
     result = parse_query(path, max_file_size=100, from_web=False)
-    assert result["local_path"].endswith("project")
+    tail = Path("project")
+    assert result["local_path"].parts[-len(tail.parts) :] == tail.parts
     assert result["slug"].endswith("project")
 
 


### PR DESCRIPTION
This PR replaces all occurrences of os.path with the `pathlib` library to enhance code clarity, maintainability, and cross-platform consistency. Key changes include:

- Converting string-based path manipulations to `Path` objects.
- Using `path.relative_to(...)` to obtain relative paths instead of naive string replacements.
- Replacing `os.path.join()`, `os.path.exists()`, `os.path.abspath(...)`, `os.path.basename(...)`, `os.path.dirname(...)`, `os.path.getctime(...)`, `os.listdir(...)`, and similar functions with the equivalent `Path` methods.

By leveraging pathlib’s object-oriented approach, we ensure fewer edge cases in path handling, especially on different operating systems. The tests have been updated to reflect these changes and should pass as expected.