### PR TITLE
chore: standardize references to "Gitingest" (resolves Issue #99)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# GitIngest
+# Gitingest
 
-[![Image](./docs/frontpage.png "GitIngest main page")](https://gitingest.com)
+[![Image](./docs/frontpage.png "Gitingest main page")](https://gitingest.com)
 
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/cyclotruc/gitingest/blob/main/LICENSE)
 [![PyPI version](https://badge.fury.io/py/gitingest.svg)](https://badge.fury.io/py/gitingest)
@@ -37,9 +37,9 @@ pip install gitingest
 ## 🧩 Browser Extension Usage
 
 <!-- markdownlint-disable MD033 -->
-<a href="https://chromewebstore.google.com/detail/adfjahbijlkjfoicpjkhjicpjpjfaood" target="_blank" title="Get GitIngest Extension from Chrome Web Store"><img height="48" src="https://github.com/user-attachments/assets/20a6e44b-fd46-4e6c-8ea6-aad436035753" alt="Available in the Chrome Web Store" /></a>
-<a href="https://addons.mozilla.org/firefox/addon/gitingest/" target="_blank" title="Get GitIngest Extension from Firefox Add-ons"><img height="48" src="https://github.com/user-attachments/assets/c0e99e6b-97cf-4af2-9737-099db7d3538b" alt="Get The Add-on for Firefox" /></a>
-<a href="https://microsoftedge.microsoft.com/addons/detail/nfobhllgcekbmpifkjlopfdfdmljmipf" target="_blank" title="Get GitIngest Extension from Firefox Add-ons"><img height="48" src="https://github.com/user-attachments/assets/204157eb-4cae-4c0e-b2cb-db514419fd9e" alt="Get from the Edge Add-ons" /></a>
+<a href="https://chromewebstore.google.com/detail/adfjahbijlkjfoicpjkhjicpjpjfaood" target="_blank" title="Get Gitingest Extension from Chrome Web Store"><img height="48" src="https://github.com/user-attachments/assets/20a6e44b-fd46-4e6c-8ea6-aad436035753" alt="Available in the Chrome Web Store" /></a>
+<a href="https://addons.mozilla.org/firefox/addon/gitingest/" target="_blank" title="Get Gitingest Extension from Firefox Add-ons"><img height="48" src="https://github.com/user-attachments/assets/c0e99e6b-97cf-4af2-9737-099db7d3538b" alt="Get The Add-on for Firefox" /></a>
+<a href="https://microsoftedge.microsoft.com/addons/detail/nfobhllgcekbmpifkjlopfdfdmljmipf" target="_blank" title="Get Gitingest Extension from Firefox Add-ons"><img height="48" src="https://github.com/user-attachments/assets/204157eb-4cae-4c0e-b2cb-db514419fd9e" alt="Get from the Edge Add-ons" /></a>
 <!-- markdownlint-enable MD033 -->
 
 The extension is open source at [lcandy2/gitingest-extension](https://github.com/lcandy2/gitingest-extension).

--- a/src/config.py
+++ b/src/config.py
@@ -5,7 +5,7 @@ TMP_BASE_PATH: str = "/tmp/gitingest"
 DELETE_REPO_AFTER: int = 60 * 60  # In seconds
 
 EXAMPLE_REPOS: list[dict[str, str]] = [
-    {"name": "GitIngest", "url": "https://github.com/cyclotruc/gitingest"},
+    {"name": "Gitingest", "url": "https://github.com/cyclotruc/gitingest"},
     {"name": "FastAPI", "url": "https://github.com/tiangolo/fastapi"},
     {"name": "Flask", "url": "https://github.com/pallets/flask"},
     {"name": "Tldraw", "url": "https://github.com/tldraw/tldraw"},

--- a/src/gitingest/cli.py
+++ b/src/gitingest/cli.py
@@ -1,4 +1,4 @@
-""" Command-line interface for the GitIngest package. """
+""" Command-line interface for the Gitingest package. """
 
 # pylint: disable=no-value-for-parameter
 

--- a/src/gitingest/exceptions.py
+++ b/src/gitingest/exceptions.py
@@ -1,4 +1,4 @@
-""" Custom exceptions for the GitIngest package. """
+""" Custom exceptions for the Gitingest package. """
 
 
 class InvalidPatternError(ValueError):

--- a/src/gitingest/ignore_patterns.py
+++ b/src/gitingest/ignore_patterns.py
@@ -1,4 +1,4 @@
-""" Default ignore patterns for GitIngest. """
+""" Default ignore patterns for Gitingest. """
 
 DEFAULT_IGNORE_PATTERNS: list[str] = [
     # Python

--- a/src/gitingest/utils.py
+++ b/src/gitingest/utils.py
@@ -1,4 +1,4 @@
-""" Utility functions for the GitIngest package. """
+""" Utility functions for the Gitingest package. """
 
 import asyncio
 import functools

--- a/src/templates/api.jinja
+++ b/src/templates/api.jinja
@@ -1,5 +1,5 @@
 {% extends "base.jinja" %}
-{% block title %}Git ingest API{% endblock %}
+{% block title %}Gitingest API{% endblock %}
 {% block content %}
     <div class="relative">
         <div class="w-full h-full absolute inset-0 bg-black rounded-xl translate-y-2 translate-x-2"></div>

--- a/src/templates/base.jinja
+++ b/src/templates/base.jinja
@@ -8,7 +8,7 @@
         <meta name="description"
               content="Replace 'hub' with 'ingest' in any Github Url for a prompt-friendly text">
         <meta name="keywords"
-              content="GitIngest, AI tools, LLM integration, Ingest, Digest, Context, Prompt, Git workflow, codebase extraction, Git repository, Git automation, Summarize, prompt-friendly">
+              content="Gitingest, AI tools, LLM integration, Ingest, Digest, Context, Prompt, Git workflow, codebase extraction, Git repository, Git automation, Summarize, prompt-friendly">
         <meta name="robots" content="index, follow">
         <!-- Favicons -->
         <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">


### PR DESCRIPTION
This PR updates all occurrences of the project name to consistently read “**Gitingest**”, aligning with the discussion in issue #99. 

- Standardizes “**Git ingest**” / “**GitIngest**” references to “**Gitingest**”
- Resolves https://github.com/cyclotruc/gitingest/issues/99
