### PR TITLE
fix: make ingest URL field case insensitive in parse_query

### DIFF
--- a/src/gitingest/parse_query.py
+++ b/src/gitingest/parse_query.py
@@ -48,6 +48,9 @@ def parse_query(
         A dictionary containing the parsed query parameters, including 'max_file_size',
         'ignore_patterns', and 'include_patterns'.
     """
+    # Normalize and clean up the source string to make it case-insensitive
+    source = source.lower().strip()
+
     # Determine the parsing method based on the source type
     if from_web or source.startswith("https://") or "github.com" in source:
         query = _parse_url(source)

--- a/tests/test_parse_query.py
+++ b/tests/test_parse_query.py
@@ -66,6 +66,16 @@ def test_parse_query_basic() -> None:
         assert "*.txt" in result["ignore_patterns"]
 
 
+def test_parse_query_mixed_case() -> None:
+    """
+    Test `parse_query` with mixed case URLs.
+    """
+    url = "Https://GitHub.COM/UsEr/rEpO"
+    result = parse_query(url, max_file_size=50, from_web=True)
+    assert result["user_name"] == "user"
+    assert result["repo_name"] == "repo"
+
+
 def test_parse_query_include_pattern() -> None:
     """
     Test `parse_query` with an include pattern.


### PR DESCRIPTION
This pull request addresses the issue where the `injest` URL field was not case insensitive, as described in https://github.com/cyclotruc/gitingest/issues/110.

### Changes:
- Added `source = source.lower()` in the `parse_query` function to handle mixed-case URLs.
- Implemented a new test `test_parse_query_mixed_case` to ensure that URLs with uppercase letters are processed correctly.

These changes ensure that URLs with different casing are correctly recognized, resolving the reported issue.

Resolves https://github.com/cyclotruc/gitingest/issues/110

