### PR TITLE
Add test for non-existent file extension pattern (*.qwerty)

### DIFF
--- a/tests/test_query_ingestion.py
+++ b/tests/test_query_ingestion.py
@@ -57,7 +57,26 @@ def test_read_file_content_with_non_notebook(tmp_path: Path):
         mock_process.assert_not_called()
 
 
-# TODO: test with include patterns: ['*.txt']
+# Test that when using a ['*.txt'] as include pattern, only .txt files are processed & .py files are excluded
+def test_include_txt_pattern(temp_directory: Path, sample_query: dict[str, Any]) -> None:
+    sample_query["local_path"] = temp_directory
+    sample_query["include_patterns"] = ["*.txt"]
+
+    result = _scan_directory(temp_directory, query=sample_query)
+    assert result is not None, "Result should not be None"
+
+    files = _extract_files_content(query=sample_query, node=result, max_file_size=1_000_000)
+    file_paths = [f["path"] for f in files]
+    assert len(files) == 5, "Should have found exactly 5 .txt files"
+    assert all(path.endswith(".txt") for path in file_paths), "Should only include .txt files"
+
+    expected_files = ["file1.txt", "subfile1.txt", "file_subdir.txt", "file_dir1.txt", "file_dir2.txt"]
+    for expected_file in expected_files:
+        assert any(expected_file in path for path in file_paths), f"Missing expected file: {expected_file}"
+
+    assert not any(path.endswith(".py") for path in file_paths), "Should not include .py files"
+
+
 # TODO: test with wrong include patterns: ['*.qwerty']
 
 

--- a/tests/test_query_ingestion.py
+++ b/tests/test_query_ingestion.py
@@ -77,7 +77,22 @@ def test_include_txt_pattern(temp_directory: Path, sample_query: dict[str, Any])
     assert not any(path.endswith(".py") for path in file_paths), "Should not include .py files"
 
 
-# TODO: test with wrong include patterns: ['*.qwerty']
+def test_include_nonexistent_extension(temp_directory: Path, sample_query: dict[str, Any]) -> None:
+    sample_query["local_path"] = temp_directory
+    sample_query["include_patterns"] = ["*.query"]  # Is a Non existant extension ?
+
+    result = _scan_directory(temp_directory, query=sample_query)
+    assert result is not None, "Result should not be None"
+
+    # Extract the files content & set file limit cap
+    files = _extract_files_content(query=sample_query, node=result, max_file_size=1_000_000)
+    # Verify no file processed with wrong extension
+    assert len(files) == 0, "Should not find any files with .qwerty extension"
+
+    assert result["type"] == "directory"
+    assert result["file_count"] == 0
+    assert result["dir_count"] == 0
+    assert len(result["children"]) == 0
 
 
 # single folder patterns


### PR DESCRIPTION
# Old version:
Test that when using a pattern for a non-existent file extension `*.qwerty`,
no files are processed despite other valid files being present in the directory.

# New version:
Test that when using a pattern for a non-existent file extension `*.qwerty`,
no files are matched or included in the result, but the directory structure
information is still captured.

This test verifies:
1. The scan completes without errors
2. No files are matched with the non-existent extension
3. Directory structure is still captured but empty since no files match
4. File information is present but content is ignored due to no matches