### PR TITLE
Make gitingest.com parsable , notebook now supports output and some metadata  

### DIFF
--- a/src/gitingest/notebook_utils.py
+++ b/src/gitingest/notebook_utils.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any
 
 
-def process_notebook(file: Path,parse_output_notebook:bool) -> str:
+def process_notebook(file: Path , parse_notebook_output: bool = True) -> str:
     """
     Process a Jupyter notebook file and return an executable Python script as a string.
 
@@ -63,7 +63,7 @@ def process_notebook(file: Path,parse_output_notebook:bool) -> str:
             str_ = f'"""\n{str_}\n"""'
 
         # Extract Output from cell
-        if parse_output_notebook and (("outputs" in cell) and (cell["outputs"] != [])):
+        if parse_notebook_output and (("outputs" in cell) and (cell["outputs"] != [])):
             sample_output=""
             for output in cell["outputs"]:
                 if output["output_type"] == "stream" and output["text"] != []:

--- a/src/gitingest/query_ingestion.py
+++ b/src/gitingest/query_ingestion.py
@@ -140,7 +140,7 @@ def _is_text_file(file_path: Path) -> bool:
         return False
 
 
-def _read_file_content(file_path: Path , parse_output_notebook: bool = True) -> str:
+def _read_file_content(file_path: Path , parse_notebook_output: bool = True) -> str:
     """
     Read the content of a file.
 
@@ -162,7 +162,7 @@ def _read_file_content(file_path: Path , parse_output_notebook: bool = True) -> 
     """
     try:
         if file_path.suffix == ".ipynb":
-            return process_notebook(file_path, parse_output_notebook)
+            return process_notebook(file_path, parse_notebook_output)
 
         with open(file_path, encoding="utf-8", errors="ignore") as f:
             return f.read()

--- a/src/gitingest/query_ingestion.py
+++ b/src/gitingest/query_ingestion.py
@@ -140,7 +140,7 @@ def _is_text_file(file_path: Path) -> bool:
         return False
 
 
-def _read_file_content(file_path: Path) -> str:
+def _read_file_content(file_path: Path , parse_output_notebook: bool = True) -> str:
     """
     Read the content of a file.
 
@@ -152,6 +152,8 @@ def _read_file_content(file_path: Path) -> str:
     ----------
     file_path : Path
         The path to the file to read.
+    parse_output_notebook : bool
+        Whether to parse the output of the notebook-cells.
 
     Returns
     -------
@@ -160,7 +162,7 @@ def _read_file_content(file_path: Path) -> str:
     """
     try:
         if file_path.suffix == ".ipynb":
-            return process_notebook(file_path)
+            return process_notebook(file_path, parse_output_notebook)
 
         with open(file_path, encoding="utf-8", errors="ignore") as f:
             return f.read()

--- a/src/gitingest/query_parser.py
+++ b/src/gitingest/query_parser.py
@@ -21,6 +21,7 @@ KNOWN_GIT_HOSTS: list[str] = [
     "bitbucket.org",
     "gitea.com",
     "codeberg.org",
+    "gitingest.com"
 ]
 
 

--- a/tests/query_parser/test_query_parser.py
+++ b/tests/query_parser/test_query_parser.py
@@ -17,6 +17,9 @@ async def test_parse_url_valid_https() -> None:
         "https://github.com/user/repo",
         "https://gitlab.com/user/repo",
         "https://bitbucket.org/user/repo",
+        "https://gitea.com/user/repo",
+        "https://codeberg.com/user/repo",
+        "https://gitingest.com/user/repo",
     ]
     for url in test_cases:
         result = await _parse_repo_source(url)
@@ -34,6 +37,8 @@ async def test_parse_url_valid_http() -> None:
         "http://github.com/user/repo",
         "http://gitlab.com/user/repo",
         "http://bitbucket.org/user/repo",
+        "https://gitingest.com/user/repo",
+        "http://gitea.com/user/repo",
     ]
     for url in test_cases:
         result = await _parse_repo_source(url)


### PR DESCRIPTION
This PR works on issue [126](https://github.com/cyclotruc/gitingest/issues/126) and issue [119](https://github.com/cyclotruc/gitingest/issues/119)

Where earlier URL consisting `gitingest.com/user/repo`  were not parsed 
- Added gitingest.com to known domain 
- Updated test-cases


Earlier Jupyter Notebook's only `source` was parsed
- Added `output` for various categories to make it pack more context
- Added metadate before every cell to make it more LLM-friendly

Example
```python

# Cell 0 ; Type : Markdown
"""
md-text
"""

...

# Cell 5 ; Type : code

print("hello_world")
print(XoR)

# Output
"""hello_world
NameError: XoR is not defined
"""
```


@cyclotruc 
@filipchristiansen (needs to update test-cases for notebook)