### PR TITLE
feat: add optional notebook cell output inclusion to `process_notebook` utility

### DIFF
--- a/src/gitingest/exceptions.py
+++ b/src/gitingest/exceptions.py
@@ -49,3 +49,10 @@ class AlreadyVisitedError(Exception):
 
     def __init__(self, path: str) -> None:
         super().__init__(f"Symlink target already visited: {path}")
+
+
+class InvalidNotebookError(Exception):
+    """Exception raised when a Jupyter notebook is invalid or cannot be processed."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)

--- a/src/gitingest/notebook_utils.py
+++ b/src/gitingest/notebook_utils.py
@@ -2,11 +2,14 @@
 
 import json
 import warnings
+from itertools import chain
 from pathlib import Path
 from typing import Any
 
+from gitingest.exceptions import InvalidNotebookError
 
-def process_notebook(file: Path) -> str:
+
+def process_notebook(file: Path, include_output: bool = True) -> str:
     """
     Process a Jupyter notebook file and return an executable Python script as a string.
 
@@ -14,6 +17,8 @@ def process_notebook(file: Path) -> str:
     ----------
     file : Path
         The path to the Jupyter notebook file.
+    include_output : bool
+        Whether to include cell outputs in the generated script, by default True.
 
     Returns
     -------
@@ -22,45 +27,127 @@ def process_notebook(file: Path) -> str:
 
     Raises
     ------
-    ValueError
-        If an unexpected cell type is encountered.
+    InvalidNotebookError
+        If the notebook file is invalid or cannot be processed.
     """
-    with file.open(encoding="utf-8") as f:
-        notebook: dict[str, Any] = json.load(f)
+    try:
+        with file.open(encoding="utf-8") as f:
+            notebook: dict[str, Any] = json.load(f)
+    except json.JSONDecodeError as e:
+        raise InvalidNotebookError(f"Invalid JSON in notebook: {file}") from e
 
     # Check if the notebook contains worksheets
     if worksheets := notebook.get("worksheets"):
-        # https://github.com/ipython/ipython/wiki/IPEP-17:-Notebook-Format-4#remove-multiple-worksheets
-        #   "The `worksheets` field is a list, but we have no UI to support multiple worksheets.
-        #   Our design has since shifted to heading-cell based structure, so we never intend to
-        #   support the multiple worksheet model. The worksheets list of lists shall be replaced
-        #   with a single list, called `cells`."
-        warnings.warn("Worksheets are deprecated as of IPEP-17.", DeprecationWarning)
+        warnings.warn(
+            "Worksheets are deprecated as of IPEP-17. Consider updating the notebook. "
+            "(See: https://github.com/jupyter/nbformat and "
+            "https://github.com/ipython/ipython/wiki/IPEP-17:-Notebook-Format-4#remove-multiple-worksheets "
+            "for more information.)",
+            DeprecationWarning,
+        )
 
         if len(worksheets) > 1:
-            warnings.warn(
-                "Multiple worksheets are not supported. Only the first worksheet will be processed.", UserWarning
-            )
+            warnings.warn("Multiple worksheets detected. Combining all worksheets into a single script.", UserWarning)
 
-        notebook = worksheets[0]
+        cells = list(chain.from_iterable(ws["cells"] for ws in worksheets))
 
-    result = []
+    else:
+        cells = notebook["cells"]
 
-    for cell in notebook["cells"]:
-        cell_type = cell.get("cell_type")
+    result = ["# Jupyter notebook converted to Python script."]
 
-        # Validate cell type and handle unexpected types
-        if cell_type not in ("markdown", "code", "raw"):
-            raise ValueError(f"Unknown cell type: {cell_type}")
+    for cell in cells:
+        if cell_str := _process_cell(cell, include_output=include_output):
+            result.append(cell_str)
 
-        str_ = "".join(cell.get("source", []))
-        if not str_:
-            continue
+    return "\n\n".join(result) + "\n"
 
-        # Convert Markdown and raw cells to multi-line comments
-        if cell_type in ("markdown", "raw"):
-            str_ = f'"""\n{str_}\n"""'
 
-        result.append(str_)
+def _process_cell(cell: dict[str, Any], include_output: bool) -> str | None:
+    """
+    Process a Jupyter notebook cell and return the cell content as a string.
 
-    return "\n\n".join(result)
+    Parameters
+    ----------
+    cell : dict[str, Any]
+        The cell dictionary from a Jupyter notebook.
+    include_output : bool
+        Whether to include cell outputs in the generated script
+
+    Returns
+    -------
+    str | None
+        The cell content as a string, or None if the cell is empty.
+
+    Raises
+    ------
+    ValueError
+        If an unexpected cell type is encountered.
+    """
+    cell_type = cell["cell_type"]
+
+    # Validate cell type and handle unexpected types
+    if cell_type not in ("markdown", "code", "raw"):
+        raise ValueError(f"Unknown cell type: {cell_type}")
+
+    cell_str = "".join(cell["source"])
+
+    # Skip empty cells
+    if not cell_str:
+        return None
+
+    # Convert Markdown and raw cells to multi-line comments
+    if cell_type in ("markdown", "raw"):
+        return f'"""\n{cell_str}\n"""'
+
+    # Add cell output as comments
+    if include_output and (outputs := cell.get("outputs")):
+
+        # Include cell outputs as comments
+        output_lines = []
+
+        for output in outputs:
+            output_lines += _extract_output(output)
+
+        for output_line in output_lines:
+            if not output_line.endswith("\n"):
+                output_line += "\n"
+
+        cell_str += "\n# Output:\n#   " + "\n#   ".join(output_lines)
+
+    return cell_str
+
+
+def _extract_output(output: dict[str, Any]) -> list[str]:
+    """
+    Extract the output from a Jupyter notebook cell.
+
+    Parameters
+    ----------
+    output : dict[str, Any]
+        The output dictionary from a Jupyter notebook cell.
+
+    Returns
+    -------
+    list[str]
+        The output as a list of strings.
+
+    Raises
+    ------
+    ValueError
+        If an unknown output type is encountered.
+    """
+    output_type = output["output_type"]
+
+    match output_type:
+        case "stream":
+            return output["text"]
+
+        case "execute_result" | "display_data":
+            return output["data"]["text/plain"]
+
+        case "error":
+            return [f"Error: {output['ename']}: {output['evalue']}"]
+
+        case _:
+            raise ValueError(f"Unknown output type: {output_type}")

--- a/src/gitingest/query_ingestion.py
+++ b/src/gitingest/query_ingestion.py
@@ -6,7 +6,12 @@ from typing import Any
 
 import tiktoken
 
-from gitingest.exceptions import AlreadyVisitedError, MaxFileSizeReachedError, MaxFilesReachedError
+from gitingest.exceptions import (
+    AlreadyVisitedError,
+    InvalidNotebookError,
+    MaxFileSizeReachedError,
+    MaxFilesReachedError,
+)
 from gitingest.notebook_utils import process_notebook
 
 MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
@@ -164,7 +169,7 @@ def _read_file_content(file_path: Path) -> str:
 
         with open(file_path, encoding="utf-8", errors="ignore") as f:
             return f.read()
-    except OSError as e:
+    except (OSError, InvalidNotebookError) as e:
         return f"Error reading file: {e}"
 
 


### PR DESCRIPTION
This PR introduces an optional parameter (`include_output`) to the `process_notebook` function, enabling control over whether code cell outputs are included in the generated Python script. 

### Key Changes
1. **`InvalidNotebookError`**: Added a new custom exception to better handle invalid or non-decodable notebook files.
2. **`process_notebook` enhancements**:
   - Accepts a new boolean parameter (`include_output`) defaulting to `True`.
   - Extracts cell outputs and appends them as commented blocks (`# Output: ...`) in the generated script if `include_output=True`.
   - Refactored internal logic into helper functions (`_process_cell`, `_extract_output`) for better readability.
3. **Exception handling**:
   - `InvalidNotebookError` is now caught alongside `OSError` when reading notebook files in `query_ingestion.py`.
4. **Unit tests**:
   - Added coverage for the new behavior in `test_notebook_utils.py` (including tests for both enabling and disabling outputs).

### Why This Change?
Previously, the script generation process did not account for cell outputs, which can be important for understanding context in code cells or for debugging. By making this feature optional, users can choose to omit outputs in large or potentially sensitive notebooks.

## Example
A single-cell notebook with:

```python
import matplotlib.pyplot as plt
print('my_data')
my_data = [1, 2, 3, 4, 5]
plt.plot(my_data)
my_data
```

will produce:

```python
# Jupyter notebook converted to Python script.

import matplotlib.pyplot as plt
print('my_data')
my_data = [1, 2, 3, 4, 5]
plt.plot(my_data)
my_data
# Output:
#   my_data

#   [1, 2, 3, 4, 5]
#   <Figure size 640x480 with 1 Axes>
```

when `include_output` is `True` (default).