### PR TITLE
refactor: replace dict-based query with ParsedQuery dataclass

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -2,6 +2,11 @@
 
 from pathlib import Path
 
+MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
+MAX_DIRECTORY_DEPTH = 20  # Maximum depth of directory traversal
+MAX_FILES = 10_000  # Maximum number of files to process
+MAX_TOTAL_SIZE_BYTES = 500 * 1024 * 1024  # 500 MB
+
 MAX_DISPLAY_SIZE: int = 300_000
 TMP_BASE_PATH = Path("/tmp/gitingest")
 DELETE_REPO_AFTER: int = 60 * 60  # In seconds

--- a/src/gitingest/cli.py
+++ b/src/gitingest/cli.py
@@ -4,7 +4,7 @@
 
 import click
 
-from gitingest.query_ingestion import MAX_FILE_SIZE
+from config import MAX_FILE_SIZE
 from gitingest.repository_ingest import ingest
 
 
@@ -49,8 +49,8 @@ async def main(
     """
     try:
         # Combine default and custom ignore patterns
-        exclude_patterns = list(exclude_pattern)
-        include_patterns = list(set(include_pattern))
+        exclude_patterns = set(exclude_pattern)
+        include_patterns = set(include_pattern)
 
         if not output:
             output = "digest.txt"
@@ -61,7 +61,7 @@ async def main(
         click.echo(summary)
 
     except Exception as e:
-        click.echo(f"Error: {str(e)}", err=True)
+        click.echo(f"Error: {e}", err=True)
         raise click.Abort()
 
 

--- a/src/gitingest/ignore_patterns.py
+++ b/src/gitingest/ignore_patterns.py
@@ -1,6 +1,6 @@
 """ Default ignore patterns for Gitingest. """
 
-DEFAULT_IGNORE_PATTERNS: list[str] = [
+DEFAULT_IGNORE_PATTERNS: set[str] = {
     # Python
     "*.pyc",
     "*.pyo",
@@ -29,18 +29,17 @@ DEFAULT_IGNORE_PATTERNS: list[str] = [
     "*.war",
     "*.ear",
     "*.nar",
-    "target/",
     ".gradle/",
     "build/",
     ".settings/",
-    ".project",
     ".classpath",
     "gradle-app.setting",
     "*.gradle",
+    # IDEs and editors / Java
+    ".project",
     # C/C++
     "*.o",
     "*.obj",
-    "*.so",
     "*.dll",
     "*.dylib",
     "*.exe",
@@ -68,14 +67,13 @@ DEFAULT_IGNORE_PATTERNS: list[str] = [
     ".ruby-gemset",
     ".rvmrc",
     # Rust
-    "target/",
     "Cargo.lock",
     "**/*.rs.bk",
+    # Java / Rust
+    "target/",
     # Go
-    "bin/",
     "pkg/",
     # .NET/C#
-    "bin/",
     "obj/",
     "*.suo",
     "*.user",
@@ -83,6 +81,8 @@ DEFAULT_IGNORE_PATTERNS: list[str] = [
     "*.sln.docstates",
     "packages/",
     "*.nupkg",
+    # Go / .NET / C#
+    "bin/",
     # Version control
     ".git",
     ".svn",
@@ -112,12 +112,9 @@ DEFAULT_IGNORE_PATTERNS: list[str] = [
     ".idea",
     ".vscode",
     ".vs",
-    "*.swp",
     "*.swo",
     "*.swn",
     ".settings",
-    ".project",
-    ".classpath",
     "*.sublime-*",
     # Temporary and cache files
     "*.log",
@@ -140,9 +137,6 @@ DEFAULT_IGNORE_PATTERNS: list[str] = [
     "*.egg",
     "*.whl",
     "*.so",
-    "*.dylib",
-    "*.dll",
-    "*.class",
     # Documentation
     "site-packages",
     ".docusaurus",
@@ -159,4 +153,4 @@ DEFAULT_IGNORE_PATTERNS: list[str] = [
     "*.tfstate*",
     ## Dependencies in various languages
     "vendor/",
-]
+}

--- a/src/gitingest/repository_ingest.py
+++ b/src/gitingest/repository_ingest.py
@@ -6,15 +6,15 @@ import shutil
 
 from config import TMP_BASE_PATH
 from gitingest.query_ingestion import run_ingest_query
-from gitingest.query_parser import parse_query
+from gitingest.query_parser import ParsedQuery, parse_query
 from gitingest.repository_clone import CloneConfig, clone_repo
 
 
 async def ingest(
     source: str,
     max_file_size: int = 10 * 1024 * 1024,  # 10 MB
-    include_patterns: list[str] | str | None = None,
-    exclude_patterns: list[str] | str | None = None,
+    include_patterns: set[str] | str | None = None,
+    exclude_patterns: set[str] | str | None = None,
     output: str | None = None,
 ) -> tuple[str, str, str]:
     """
@@ -31,10 +31,10 @@ async def ingest(
     max_file_size : int
         Maximum allowed file size for file ingestion. Files larger than this size are ignored, by default
         10*1024*1024 (10 MB).
-    include_patterns : list[str] | str | None, optional
-        Pattern or list of patterns specifying which files to include. If `None`, all files are included.
-    exclude_patterns : list[str] | str | None, optional
-        Pattern or list of patterns specifying which files to exclude. If `None`, no files are excluded.
+    include_patterns : set[str] | str | None, optional
+        Pattern or set of patterns specifying which files to include. If `None`, all files are included.
+    exclude_patterns : set[str] | str | None, optional
+        Pattern or set of patterns specifying which files to exclude. If `None`, no files are excluded.
     output : str | None, optional
         File path where the summary and content should be written. If `None`, the results are not written to a file.
 
@@ -52,21 +52,21 @@ async def ingest(
         If `clone_repo` does not return a coroutine, or if the `source` is of an unsupported type.
     """
     try:
-        query = await parse_query(
+        parsed_query: ParsedQuery = await parse_query(
             source=source,
             max_file_size=max_file_size,
             from_web=False,
             include_patterns=include_patterns,
             ignore_patterns=exclude_patterns,
         )
-        if query["url"]:
 
+        if parsed_query.url:
             # Extract relevant fields for CloneConfig
             clone_config = CloneConfig(
-                url=query["url"],
-                local_path=str(query["local_path"]),
-                commit=query.get("commit"),
-                branch=query.get("branch"),
+                url=parsed_query.url,
+                local_path=str(parsed_query.local_path),
+                commit=parsed_query.commit,
+                branch=parsed_query.branch,
             )
             clone_result = clone_repo(clone_config)
 
@@ -75,7 +75,7 @@ async def ingest(
             else:
                 raise TypeError("clone_repo did not return a coroutine as expected.")
 
-        summary, tree, content = run_ingest_query(query)
+        summary, tree, content = run_ingest_query(parsed_query)
 
         if output is not None:
             with open(output, "w", encoding="utf-8") as f:
@@ -84,6 +84,6 @@ async def ingest(
         return summary, tree, content
     finally:
         # Clean up the temporary directory if it was created
-        if query["url"]:
+        if parsed_query.url:
             # Clean up the temporary directory
             shutil.rmtree(TMP_BASE_PATH, ignore_errors=True)

--- a/src/main.py
+++ b/src/main.py
@@ -57,7 +57,7 @@ async def remove_old_repositories():
                 await process_folder(folder)
 
         except Exception as e:
-            print(f"Error in remove_old_repositories: {str(e)}")
+            print(f"Error in remove_old_repositories: {e}")
 
         await asyncio.sleep(60)
 
@@ -83,13 +83,13 @@ async def process_folder(folder: Path) -> None:
                 history.write(f"{repo_url}\n")
 
     except Exception as e:
-        print(f"Error logging repository URL for {folder}: {str(e)}")
+        print(f"Error logging repository URL for {folder}: {e}")
 
     # Delete the folder
     try:
         shutil.rmtree(folder)
     except Exception as e:
-        print(f"Error deleting {folder}: {str(e)}")
+        print(f"Error deleting {folder}: {e}")
 
 
 @asynccontextmanager

--- a/src/query_processor.py
+++ b/src/query_processor.py
@@ -8,7 +8,7 @@ from starlette.templating import _TemplateResponse
 
 from config import EXAMPLE_REPOS, MAX_DISPLAY_SIZE
 from gitingest.query_ingestion import run_ingest_query
-from gitingest.query_parser import parse_query
+from gitingest.query_parser import ParsedQuery, parse_query
 from gitingest.repository_clone import CloneConfig, clone_repo
 from server_utils import Colors, log_slider_to_size
 
@@ -77,27 +77,30 @@ async def process_query(
     }
 
     try:
-        query = await parse_query(
+        parsed_query: ParsedQuery = await parse_query(
             source=input_text,
             max_file_size=max_file_size,
             from_web=True,
             include_patterns=include_patterns,
             ignore_patterns=exclude_patterns,
         )
+        if not parsed_query.url:
+            raise ValueError("The 'url' parameter is required.")
+
         clone_config = CloneConfig(
-            url=query["url"],
-            local_path=str(query["local_path"]),
-            commit=query.get("commit"),
-            branch=query.get("branch"),
+            url=parsed_query.url,
+            local_path=str(parsed_query.local_path),
+            commit=parsed_query.commit,
+            branch=parsed_query.branch,
         )
         await clone_repo(clone_config)
-        summary, tree, content = run_ingest_query(query)
+        summary, tree, content = run_ingest_query(parsed_query)
         with open(f"{clone_config.local_path}.txt", "w", encoding="utf-8") as f:
             f.write(tree + "\n" + content)
     except Exception as e:
         # hack to print error message when query is not defined
-        if "query" in locals() and query is not None and isinstance(query, dict):
-            _print_error(query["url"], e, max_file_size, pattern_type, pattern)
+        if "query" in locals() and parsed_query is not None and isinstance(parsed_query, dict):
+            _print_error(parsed_query["url"], e, max_file_size, pattern_type, pattern)
         else:
             print(f"{Colors.BROWN}WARN{Colors.END}: {Colors.RED}<-  {Colors.END}", end="")
             print(f"{Colors.RED}{e}{Colors.END}")
@@ -112,7 +115,7 @@ async def process_query(
         )
 
     _print_success(
-        url=query["url"],
+        url=parsed_query.url,
         max_file_size=max_file_size,
         pattern_type=pattern_type,
         pattern=pattern,
@@ -125,7 +128,7 @@ async def process_query(
             "summary": summary,
             "tree": tree,
             "content": content,
-            "ingest_id": query["id"],
+            "ingest_id": parsed_query.id,
         }
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,22 +6,25 @@ from typing import Any
 
 import pytest
 
+from gitingest.query_parser import ParsedQuery
+
 
 @pytest.fixture
-def sample_query() -> dict[str, Any]:
-    return {
-        "user_name": "test_user",
-        "repo_name": "test_repo",
-        "local_path": Path("/tmp/test_repo").resolve(),
-        "subpath": "/",
-        "branch": "main",
-        "commit": None,
-        "max_file_size": 1_000_000,
-        "slug": "test_user/test_repo",
-        "ignore_patterns": ["*.pyc", "__pycache__", ".git"],
-        "include_patterns": None,
-        "pattern_type": "exclude",
-    }
+def sample_query() -> ParsedQuery:
+    return ParsedQuery(
+        user_name="test_user",
+        repo_name="test_repo",
+        url=None,
+        subpath="/",
+        local_path=Path("/tmp/test_repo").resolve(),
+        slug="test_user/test_repo",
+        id="id",
+        branch="main",
+        max_file_size=1_000_000,
+        ignore_patterns={"*.pyc", "__pycache__", ".git"},
+        include_patterns=None,
+        pattern_type="exclude",
+    )
 
 
 @pytest.fixture

--- a/tests/query_parser/test_git_host_agnostic.py
+++ b/tests/query_parser/test_git_host_agnostic.py
@@ -68,14 +68,13 @@ async def test_parse_query_without_host(
     expected_url: str,
 ) -> None:
     for url in urls:
-        result = await parse_query(url, max_file_size=50, from_web=True)
-        # Common assertions for all cases
-        assert result["user_name"] == expected_user
-        assert result["repo_name"] == expected_repo
-        assert result["url"] == expected_url
-        assert result["slug"] == f"{expected_user}-{expected_repo}"
-        assert result["id"] is not None
-        assert result["subpath"] == "/"
-        assert result["branch"] is None
-        assert result["commit"] is None
-        assert result["type"] is None
+        parsed_query = await parse_query(url, max_file_size=50, from_web=True)
+        assert parsed_query.user_name == expected_user
+        assert parsed_query.repo_name == expected_repo
+        assert parsed_query.url == expected_url
+        assert parsed_query.slug == f"{expected_user}-{expected_repo}"
+        assert parsed_query.id is not None
+        assert parsed_query.subpath == "/"
+        assert parsed_query.branch is None
+        assert parsed_query.commit is None
+        assert parsed_query.type is None


### PR DESCRIPTION
This PR replaces the old dictionary-based query object with a new `ParsedQuery` dataclass, improving type safety and readability across the codebase. 

### Key points:
- Introduces a `ParsedQuery` `dataclass` that consolidates all query-related fields (repo, branch, commit, patterns, etc.)

- Updates the following functions in the `query_parser` module to return a query of type `ParsedQuery` (instead of `dict[str, Any]`):
  - `_parse_repo_source`
  - `_parse_path`
  - `parse_query`

- Updates the following functions in the `query_ingestion` module to take a query argument of type `ParsedQuery` (instead of `dict[str, Any]`):
  - `run_ingest_query`
  - `_ingest_directory`
  - `_ingest_single_file`
  - `_create_tree_structure`
  - `_create_summary_string`
  - `_extract_files_content`
  - `_process_item`
  - `_process_symlink`
  - `_scan_directory`

- Switches ignore/include patterns to sets for clearer overrides and deduplication
- Moves or imports maximum size constants (`MAX_FILE_SIZE`, etc.) to `config.py`
- Aligns all references and tests to the new `dataclass` approach

This unification makes it easier to understand and maintain how query data flows through the ingestion process.