### PR TITLE
refactor: refactor CLI to properly await async logic via a synchronous Click command

### DIFF
--- a/src/gitingest/cli.py
+++ b/src/gitingest/cli.py
@@ -2,6 +2,8 @@
 
 # pylint: disable=no-value-for-parameter
 
+import asyncio
+
 import click
 
 from gitingest.query_ingestion import MAX_FILE_SIZE
@@ -9,12 +11,42 @@ from gitingest.repository_ingest import ingest
 
 
 @click.command()
-@click.argument("source", type=str, required=True)
+@click.argument("source", type=str, default=".")
 @click.option("--output", "-o", default=None, help="Output file path (default: <repo_name>.txt in current directory)")
 @click.option("--max-size", "-s", default=MAX_FILE_SIZE, help="Maximum file size to process in bytes")
 @click.option("--exclude-pattern", "-e", multiple=True, help="Patterns to exclude")
 @click.option("--include-pattern", "-i", multiple=True, help="Patterns to include")
-async def main(
+def main(
+    source: str,
+    output: str | None,
+    max_size: int,
+    exclude_pattern: tuple[str, ...],
+    include_pattern: tuple[str, ...],
+):
+    """
+    Main entry point for the CLI. This function is called when the CLI is run as a script.
+
+    It calls the async main function to run the command.
+
+    Parameters
+    ----------
+    source : str
+        The source directory or repository to analyze.
+    output : str | None
+        The path where the output file will be written. If not specified, the output will be written
+        to a file named `<repo_name>.txt` in the current directory.
+    max_size : int
+        The maximum file size to process, in bytes. Files larger than this size will be ignored.
+    exclude_pattern : tuple[str, ...]
+        A tuple of patterns to exclude during the analysis. Files matching these patterns will be ignored.
+    include_pattern : tuple[str, ...]
+        A tuple of patterns to include during the analysis. Only files matching these patterns will be processed.
+    """
+    # Main entry point for the CLI. This function is called when the CLI is run as a script.
+    asyncio.run(_async_main(source, output, max_size, exclude_pattern, include_pattern))
+
+
+async def _async_main(
     source: str,
     output: str | None,
     max_size: int,
@@ -24,9 +56,8 @@ async def main(
     """
     Analyze a directory or repository and create a text dump of its contents.
 
-    This command analyzes the contents of a specified source directory or repository,
-    applies custom include and exclude patterns, and generates a text summary of the analysis
-    which is then written to an output file.
+    This command analyzes the contents of a specified source directory or repository, applies custom include and
+    exclude patterns, and generates a text summary of the analysis which is then written to an output file.
 
     Parameters
     ----------


### PR DESCRIPTION
**Summary**

This PR fixes the`coroutine 'main' was never awaited` `RuntimeWarning` by introducing a synchronous Click command (`main`) that wraps an async function (`_async_main`) with `asyncio.run()`. This approach ensures that Click’s command decorators see a normal sync function, while the actual logic runs asynchronously (and is properly awaited).

**Key Changes**
- Added `_async_main(...)` function for the actual async logic.
- Updated the Click-decorated `main(...)` to be synchronous, which calls `_async_main(...)` via `asyncio.run()`.
- Removed the previous direct `async def` usage under Click’s command decorator.

**Benefits**
- No more `RuntimeWarning` about un-awaited coroutines.
- Cleaner separation of concerns between sync CLI handling and async operations.

May be related to https://github.com/cyclotruc/gitingest/issues/125.