### PR TITLE
Resolves #109, File Tree Lines can be Added to Exclude/Include Pattern Through Click

### DIFF
--- a/src/server/templates/components/git_form.jinja
+++ b/src/server/templates/components/git_form.jinja
@@ -1,3 +1,24 @@
+<script>
+    function changePattern(element) {
+        console.log("Pattern changed", element.value);
+        let patternType = element.value;
+        const files = document.getElementsByName("tree-line");
+        
+        Array.from(files).forEach((element) => {
+            if (element.textContent.includes("Directory structure:")) {
+                return;
+            }
+
+            element.classList.toggle('line-through');
+            element.classList.toggle('text-gray-500');
+            element.classList.toggle('hover:text-inherit');
+            element.classList.toggle('hover:no-underline');
+            element.classList.toggle('hover:line-through');
+            element.classList.toggle('hover:text-gray-500'); 
+        });
+    }
+</script>
+
 <div class="relative">
     <div class="w-full h-full absolute inset-0 bg-gray-900 rounded-xl translate-y-2 translate-x-2"></div>
     <div class="rounded-xl relative z-20 pl-8 sm:pl-10 pr-8 sm:pr-16 py-8 border-[3px] border-gray-900 bg-[#fff4da]">
@@ -34,6 +55,7 @@
                     <div class="flex relative z-20 border-[3px] border-gray-900 rounded bg-white">
                         <div class="relative flex items-center">
                             <select id="pattern_type"
+                                    onchange = "changePattern(this)"
                                     name="pattern_type"
                                     class="w-21 py-2 pl-2 pr-6 appearance-none bg-[#e6e8eb] focus:outline-none border-r-[3px] border-gray-900">
                                 <option value="exclude"

--- a/src/server/templates/components/git_form.jinja
+++ b/src/server/templates/components/git_form.jinja
@@ -3,7 +3,7 @@
         console.log("Pattern changed", element.value);
         let patternType = element.value;
         const files = document.getElementsByName("tree-line");
-        
+
         Array.from(files).forEach((element) => {
             if (element.textContent.includes("Directory structure:")) {
                 return;
@@ -14,11 +14,10 @@
             element.classList.toggle('hover:text-inherit');
             element.classList.toggle('hover:no-underline');
             element.classList.toggle('hover:line-through');
-            element.classList.toggle('hover:text-gray-500'); 
+            element.classList.toggle('hover:text-gray-500');
         });
     }
 </script>
-
 <div class="relative">
     <div class="w-full h-full absolute inset-0 bg-gray-900 rounded-xl translate-y-2 translate-x-2"></div>
     <div class="rounded-xl relative z-20 pl-8 sm:pl-10 pr-8 sm:pr-16 py-8 border-[3px] border-gray-900 bg-[#fff4da]">
@@ -55,7 +54,7 @@
                     <div class="flex relative z-20 border-[3px] border-gray-900 rounded bg-white">
                         <div class="relative flex items-center">
                             <select id="pattern_type"
-                                    onchange = "changePattern(this)"
+                                    onchange="changePattern(this)"
                                     name="pattern_type"
                                     class="w-21 py-2 pl-2 pr-6 appearance-none bg-[#e6e8eb] focus:outline-none border-r-[3px] border-gray-900">
                                 <option value="exclude"

--- a/src/server/templates/components/result.jinja
+++ b/src/server/templates/components/result.jinja
@@ -91,7 +91,7 @@
                         </div>
                         <div class="relative">
                             <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0"></div>
-                            <div class="directory-structure w-full p-4 bg-[#fff4da] border-[3px] border-gray-900 rounded font-mono text-sm resize-y focus:outline-none relative z-10 h-[215px] overflow-scroll" readonly>
+                            <div class="directory-structure w-full p-4 bg-[#fff4da] border-[3px] border-gray-900 rounded font-mono text-sm resize-y focus:outline-none relative z-10 h-[215px] overflow-auto" readonly>
                                 {% for line in tree.splitlines()%}
                                     <div name="tree-line" class="cursor-pointer hover:line-through hover:text-gray-500" onclick="toggleFile(this)">{{ line }}</div>
                                 {% endfor %}

--- a/src/server/templates/components/result.jinja
+++ b/src/server/templates/components/result.jinja
@@ -29,108 +29,104 @@
     }
 </script>
 {% if result %}
-<div class="mt-10" data-results>
-    <div class="relative">
-        <div class="w-full h-full absolute inset-0 bg-gray-900 rounded-xl translate-y-2 translate-x-2"></div>
-        <div class="bg-[#fafafa] rounded-xl border-[3px] border-gray-900 p-6 relative z-20 space-y-6">
-            <!-- Summary and Directory Structure -->
-            <div class="grid grid-cols-1 md:grid-cols-12 gap-6">
-                <!-- Summary Column -->
-                <div class="md:col-span-5">
-                    <div class="flex justify-between items-center mb-4 py-2">
-                        <h3 class="text-lg font-bold text-gray-900">Summary</h3>
-                    </div>
-                    <div class="relative">
-                        <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0">
+    <div class="mt-10" data-results>
+        <div class="relative">
+            <div class="w-full h-full absolute inset-0 bg-gray-900 rounded-xl translate-y-2 translate-x-2"></div>
+            <div class="bg-[#fafafa] rounded-xl border-[3px] border-gray-900 p-6 relative z-20 space-y-6">
+                <!-- Summary and Directory Structure -->
+                <div class="grid grid-cols-1 md:grid-cols-12 gap-6">
+                    <!-- Summary Column -->
+                    <div class="md:col-span-5">
+                        <div class="flex justify-between items-center mb-4 py-2">
+                            <h3 class="text-lg font-bold text-gray-900">Summary</h3>
                         </div>
-                        <textarea
-                            class="w-full h-[160px] p-4 bg-[#fff4da] border-[3px] border-gray-900 rounded font-mono text-sm resize-none focus:outline-none relative z-10"
-                            readonly>{{ summary }}</textarea>
-                    </div>
-                    {% if ingest_id %}
-                    <div class="relative mt-4 inline-block group">
-                        <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0">
+                        <div class="relative">
+                            <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0"></div>
+                            <textarea class="w-full h-[160px] p-4 bg-[#fff4da] border-[3px] border-gray-900 rounded font-mono text-sm resize-none focus:outline-none relative z-10"
+                                      readonly>{{ summary }}</textarea>
                         </div>
-                        <a href="/download/{{ ingest_id }}"
-                            class="inline-flex items-center px-4 py-2 bg-[#ffc480] border-[3px] border-gray-900 text-gray-900 rounded group-hover:-translate-y-px group-hover:-translate-x-px transition-transform relative z-10">
-                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                    d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-                            </svg>
-                            Download
-                        </a>
-                    </div>
-                    <div class="relative mt-4 inline-block group ml-4">
-                        <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0">
-                        </div>
-                        <button onclick="copyFullDigest()"
-                            class="inline-flex items-center px-4 py-2 bg-[#ffc480] border-[3px] border-gray-900 text-gray-900 rounded group-hover:-translate-y-px group-hover:-translate-x-px transition-transform relative z-10">
-                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                    d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" />
-                            </svg>
-                            Copy all
-                        </button>
-                    </div>
-                    {% endif %}
-                </div>
-                <!-- Directory Structure Column -->
-                <div class="md:col-span-7">
-                    <div class="flex justify-between items-center mb-4">
-                        <h3 class="text-lg font-bold text-gray-900">Directory Structure</h3>
-                        <div class="relative group">
-                            <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0">
+                        {% if ingest_id %}
+                            <div class="relative mt-4 inline-block group">
+                                <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0"></div>
+                                <a href="/download/{{ ingest_id }}"
+                                   class="inline-flex items-center px-4 py-2 bg-[#ffc480] border-[3px] border-gray-900 text-gray-900 rounded group-hover:-translate-y-px group-hover:-translate-x-px transition-transform relative z-10">
+                                    <svg class="w-4 h-4 mr-2"
+                                         fill="none"
+                                         stroke="currentColor"
+                                         viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                                    </svg>
+                                    Download
+                                </a>
                             </div>
-                            <button onclick="copyText('directory-structure')"
-                                class="px-4 py-2 bg-[#ffc480] border-[3px] border-gray-900 text-gray-900 rounded group-hover:-translate-y-px group-hover:-translate-x-px transition-transform relative z-10 flex items-center gap-2">
+                            <div class="relative mt-4 inline-block group ml-4">
+                                <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0"></div>
+                                <button onclick="copyFullDigest()"
+                                        class="inline-flex items-center px-4 py-2 bg-[#ffc480] border-[3px] border-gray-900 text-gray-900 rounded group-hover:-translate-y-px group-hover:-translate-x-px transition-transform relative z-10">
+                                    <svg class="w-4 h-4 mr-2"
+                                         fill="none"
+                                         stroke="currentColor"
+                                         viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" />
+                                    </svg>
+                                    Copy all
+                                </button>
+                            </div>
+                        {% endif %}
+                    </div>
+                    <!-- Directory Structure Column -->
+                    <div class="md:col-span-7">
+                        <div class="flex justify-between items-center mb-4">
+                            <h3 class="text-lg font-bold text-gray-900">Directory Structure</h3>
+                            <div class="relative group">
+                                <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0"></div>
+                                <button onclick="copyText('directory-structure')"
+                                        class="px-4 py-2 bg-[#ffc480] border-[3px] border-gray-900 text-gray-900 rounded group-hover:-translate-y-px group-hover:-translate-x-px transition-transform relative z-10 flex items-center gap-2">
+                                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" />
+                                    </svg>
+                                    Copy
+                                </button>
+                            </div>
+                        </div>
+                        <div class="relative">
+                            <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0"></div>
+                            <div class="directory-structure w-full p-4 bg-[#fff4da] border-[3px] border-gray-900 rounded font-mono text-sm resize-y focus:outline-none relative z-10 h-[215px] overflow-auto"
+                                 id="directory-structure-container"
+                                 readonly>
+                                <input type="hidden" id="directory-structure-content" value="{{ tree }}" />
+                                {% for line in tree.splitlines() %}
+                                    <div name="tree-line"
+                                         class="cursor-pointer hover:line-through hover:text-gray-500"
+                                         onclick="toggleFile(this)">{{ line }}</div>
+                                {% endfor %}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <!-- Full Digest -->
+                <div>
+                    <div class="flex justify-between items-center mb-4">
+                        <h3 class="text-lg font-bold text-gray-900">Files Content</h3>
+                        <div class="relative group">
+                            <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0"></div>
+                            <button onclick="copyText('result-text')"
+                                    class="px-4 py-2 bg-[#ffc480] border-[3px] border-gray-900 text-gray-900 rounded group-hover:-translate-y-px group-hover:-translate-x-px transition-transform relative z-10 flex items-center gap-2">
                                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                        d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" />
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" />
                                 </svg>
                                 Copy
                             </button>
                         </div>
                     </div>
                     <div class="relative">
-                        <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0">
-                        </div>
-                        <div class="directory-structure w-full p-4 bg-[#fff4da] border-[3px] border-gray-900 rounded font-mono text-sm resize-y focus:outline-none relative z-10 h-[215px] overflow-auto"
-                            id="directory-structure-container" readonly>
-                            <input type="hidden" id="directory-structure-content" value="{{ tree }}" />
-                            {% for line in tree.splitlines() %}
-                            <div name="tree-line" class="cursor-pointer hover:line-through hover:text-gray-500"
-                                onclick="toggleFile(this)">{{ line }}</div>
-                            {% endfor %}
-                        </div>
+                        <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0"></div>
+                        <textarea class="result-text w-full p-4 bg-[#fff4da] border-[3px] border-gray-900 rounded font-mono text-sm resize-y focus:outline-none relative z-10"
+                                  style="min-height: {{ '600px' if content else 'calc(100vh-800px)' }}"
+                                  readonly>{{ content }}</textarea>
                     </div>
-                </div>
-            </div>
-            <!-- Full Digest -->
-            <div>
-                <div class="flex justify-between items-center mb-4">
-                    <h3 class="text-lg font-bold text-gray-900">Files Content</h3>
-                    <div class="relative group">
-                        <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0">
-                        </div>
-                        <button onclick="copyText('result-text')"
-                            class="px-4 py-2 bg-[#ffc480] border-[3px] border-gray-900 text-gray-900 rounded group-hover:-translate-y-px group-hover:-translate-x-px transition-transform relative z-10 flex items-center gap-2">
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                    d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" />
-                            </svg>
-                            Copy
-                        </button>
-                    </div>
-                </div>
-                <div class="relative">
-                    <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0"></div>
-                    <textarea
-                        class="result-text w-full p-4 bg-[#fff4da] border-[3px] border-gray-900 rounded font-mono text-sm resize-y focus:outline-none relative z-10"
-                        style="min-height: {{ '600px' if content else 'calc(100vh-800px)' }}"
-                        readonly>{{ content }}</textarea>
                 </div>
             </div>
         </div>
     </div>
-</div>
 {% endif %}

--- a/src/server/templates/components/result.jinja
+++ b/src/server/templates/components/result.jinja
@@ -29,102 +29,108 @@
     }
 </script>
 {% if result %}
-    <div class="mt-10" data-results>
-        <div class="relative">
-            <div class="w-full h-full absolute inset-0 bg-gray-900 rounded-xl translate-y-2 translate-x-2"></div>
-            <div class="bg-[#fafafa] rounded-xl border-[3px] border-gray-900 p-6 relative z-20 space-y-6">
-                <!-- Summary and Directory Structure -->
-                <div class="grid grid-cols-1 md:grid-cols-12 gap-6">
-                    <!-- Summary Column -->
-                    <div class="md:col-span-5">
-                        <div class="flex justify-between items-center mb-4 py-2">
-                            <h3 class="text-lg font-bold text-gray-900">Summary</h3>
-                        </div>
-                        <div class="relative">
-                            <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0"></div>
-                            <textarea class="w-full h-[160px] p-4 bg-[#fff4da] border-[3px] border-gray-900 rounded font-mono text-sm resize-none focus:outline-none relative z-10"
-                                      readonly>{{ summary }}</textarea>
-                        </div>
-                        {% if ingest_id %}
-                            <div class="relative mt-4 inline-block group">
-                                <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0"></div>
-                                <a href="/download/{{ ingest_id }}"
-                                   class="inline-flex items-center px-4 py-2 bg-[#ffc480] border-[3px] border-gray-900 text-gray-900 rounded group-hover:-translate-y-px group-hover:-translate-x-px transition-transform relative z-10">
-                                    <svg class="w-4 h-4 mr-2"
-                                         fill="none"
-                                         stroke="currentColor"
-                                         viewBox="0 0 24 24">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-                                    </svg>
-                                    Download
-                                </a>
-                            </div>
-                            <div class="relative mt-4 inline-block group ml-4">
-                                <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0"></div>
-                                <button onclick="copyFullDigest()"
-                                        class="inline-flex items-center px-4 py-2 bg-[#ffc480] border-[3px] border-gray-900 text-gray-900 rounded group-hover:-translate-y-px group-hover:-translate-x-px transition-transform relative z-10">
-                                    <svg class="w-4 h-4 mr-2"
-                                         fill="none"
-                                         stroke="currentColor"
-                                         viewBox="0 0 24 24">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" />
-                                    </svg>
-                                    Copy all
-                                </button>
-                            </div>
-                        {% endif %}
+<div class="mt-10" data-results>
+    <div class="relative">
+        <div class="w-full h-full absolute inset-0 bg-gray-900 rounded-xl translate-y-2 translate-x-2"></div>
+        <div class="bg-[#fafafa] rounded-xl border-[3px] border-gray-900 p-6 relative z-20 space-y-6">
+            <!-- Summary and Directory Structure -->
+            <div class="grid grid-cols-1 md:grid-cols-12 gap-6">
+                <!-- Summary Column -->
+                <div class="md:col-span-5">
+                    <div class="flex justify-between items-center mb-4 py-2">
+                        <h3 class="text-lg font-bold text-gray-900">Summary</h3>
                     </div>
-                    <!-- Directory Structure Column -->
-                    <div class="md:col-span-7">
-                        <div class="flex justify-between items-center mb-4">
-                            <h3 class="text-lg font-bold text-gray-900">Directory Structure</h3>
-                            <div class="relative group">
-                                <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0"></div>
-                                <button onclick="copyText('directory-structure')"
-                                        class="px-4 py-2 bg-[#ffc480] border-[3px] border-gray-900 text-gray-900 rounded group-hover:-translate-y-px group-hover:-translate-x-px transition-transform relative z-10 flex items-center gap-2">
-                                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" />
-                                    </svg>
-                                    Copy
-                                </button>
-                            </div>
+                    <div class="relative">
+                        <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0">
                         </div>
-                        <div class="relative">
-                            <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0"></div>
-                            <div class="directory-structure w-full p-4 bg-[#fff4da] border-[3px] border-gray-900 rounded font-mono text-sm resize-y focus:outline-none relative z-10 h-[215px] overflow-auto"
-                                 readonly>
-                                {% for line in tree.splitlines() %}
-                                    <div name="tree-line"
-                                         class="cursor-pointer hover:line-through hover:text-gray-500"
-                                         onclick="toggleFile(this)">{{ line }}</div>
-                                {% endfor %}
-                            </div>
-                        </div>
+                        <textarea
+                            class="w-full h-[160px] p-4 bg-[#fff4da] border-[3px] border-gray-900 rounded font-mono text-sm resize-none focus:outline-none relative z-10"
+                            readonly>{{ summary }}</textarea>
                     </div>
+                    {% if ingest_id %}
+                    <div class="relative mt-4 inline-block group">
+                        <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0">
+                        </div>
+                        <a href="/download/{{ ingest_id }}"
+                            class="inline-flex items-center px-4 py-2 bg-[#ffc480] border-[3px] border-gray-900 text-gray-900 rounded group-hover:-translate-y-px group-hover:-translate-x-px transition-transform relative z-10">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                    d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                            </svg>
+                            Download
+                        </a>
+                    </div>
+                    <div class="relative mt-4 inline-block group ml-4">
+                        <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0">
+                        </div>
+                        <button onclick="copyFullDigest()"
+                            class="inline-flex items-center px-4 py-2 bg-[#ffc480] border-[3px] border-gray-900 text-gray-900 rounded group-hover:-translate-y-px group-hover:-translate-x-px transition-transform relative z-10">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                    d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" />
+                            </svg>
+                            Copy all
+                        </button>
+                    </div>
+                    {% endif %}
                 </div>
-                <!-- Full Digest -->
-                <div>
+                <!-- Directory Structure Column -->
+                <div class="md:col-span-7">
                     <div class="flex justify-between items-center mb-4">
-                        <h3 class="text-lg font-bold text-gray-900">Files Content</h3>
+                        <h3 class="text-lg font-bold text-gray-900">Directory Structure</h3>
                         <div class="relative group">
-                            <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0"></div>
-                            <button onclick="copyText('result-text')"
-                                    class="px-4 py-2 bg-[#ffc480] border-[3px] border-gray-900 text-gray-900 rounded group-hover:-translate-y-px group-hover:-translate-x-px transition-transform relative z-10 flex items-center gap-2">
+                            <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0">
+                            </div>
+                            <button onclick="copyText('directory-structure')"
+                                class="px-4 py-2 bg-[#ffc480] border-[3px] border-gray-900 text-gray-900 rounded group-hover:-translate-y-px group-hover:-translate-x-px transition-transform relative z-10 flex items-center gap-2">
                                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" />
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                        d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" />
                                 </svg>
                                 Copy
                             </button>
                         </div>
                     </div>
                     <div class="relative">
-                        <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0"></div>
-                        <textarea class="result-text w-full p-4 bg-[#fff4da] border-[3px] border-gray-900 rounded font-mono text-sm resize-y focus:outline-none relative z-10"
-                                  style="min-height: {{ '600px' if content else 'calc(100vh-800px)' }}"
-                                  readonly>{{ content }}</textarea>
+                        <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0">
+                        </div>
+                        <div class="directory-structure w-full p-4 bg-[#fff4da] border-[3px] border-gray-900 rounded font-mono text-sm resize-y focus:outline-none relative z-10 h-[215px] overflow-auto"
+                            id="directory-structure-container" readonly>
+                            <input type="hidden" id="directory-structure-content" value="{{ tree }}" />
+                            {% for line in tree.splitlines() %}
+                            <div name="tree-line" class="cursor-pointer hover:line-through hover:text-gray-500"
+                                onclick="toggleFile(this)">{{ line }}</div>
+                            {% endfor %}
+                        </div>
                     </div>
+                </div>
+            </div>
+            <!-- Full Digest -->
+            <div>
+                <div class="flex justify-between items-center mb-4">
+                    <h3 class="text-lg font-bold text-gray-900">Files Content</h3>
+                    <div class="relative group">
+                        <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0">
+                        </div>
+                        <button onclick="copyText('result-text')"
+                            class="px-4 py-2 bg-[#ffc480] border-[3px] border-gray-900 text-gray-900 rounded group-hover:-translate-y-px group-hover:-translate-x-px transition-transform relative z-10 flex items-center gap-2">
+                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                    d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" />
+                            </svg>
+                            Copy
+                        </button>
+                    </div>
+                </div>
+                <div class="relative">
+                    <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0"></div>
+                    <textarea
+                        class="result-text w-full p-4 bg-[#fff4da] border-[3px] border-gray-900 rounded font-mono text-sm resize-y focus:outline-none relative z-10"
+                        style="min-height: {{ '600px' if content else 'calc(100vh-800px)' }}"
+                        readonly>{{ content }}</textarea>
                 </div>
             </div>
         </div>
     </div>
+</div>
 {% endif %}

--- a/src/server/templates/components/result.jinja
+++ b/src/server/templates/components/result.jinja
@@ -1,7 +1,7 @@
 <script>
     function getFileName(line) {
         // Skips "|", "└", "├" found in file tree
-        const index = line.search(/[a-zA-Z0-9]/); 
+        const index = line.search(/[a-zA-Z0-9]/);
         return line.substring(index).trim();
     }
 
@@ -15,7 +15,7 @@
 
         element.classList.toggle('line-through');
         element.classList.toggle('text-gray-500');
-        
+
         const fileName = getFileName(element.textContent);
         const fileIndex = patternFiles.indexOf(fileName);
 
@@ -91,9 +91,12 @@
                         </div>
                         <div class="relative">
                             <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0"></div>
-                            <div class="directory-structure w-full p-4 bg-[#fff4da] border-[3px] border-gray-900 rounded font-mono text-sm resize-y focus:outline-none relative z-10 h-[215px] overflow-auto" readonly>
-                                {% for line in tree.splitlines()%}
-                                    <div name="tree-line" class="cursor-pointer hover:line-through hover:text-gray-500" onclick="toggleFile(this)">{{ line }}</div>
+                            <div class="directory-structure w-full p-4 bg-[#fff4da] border-[3px] border-gray-900 rounded font-mono text-sm resize-y focus:outline-none relative z-10 h-[215px] overflow-auto"
+                                 readonly>
+                                {% for line in tree.splitlines() %}
+                                    <div name="tree-line"
+                                         class="cursor-pointer hover:line-through hover:text-gray-500"
+                                         onclick="toggleFile(this)">{{ line }}</div>
                                 {% endfor %}
                             </div>
                         </div>

--- a/src/server/templates/components/result.jinja
+++ b/src/server/templates/components/result.jinja
@@ -1,3 +1,33 @@
+<script>
+    function getFileName(line) {
+        // Skips "|", "└", "├" found in file tree
+        const index = line.search(/[a-zA-Z0-9]/); 
+        return line.substring(index).trim();
+    }
+
+    function toggleFile(element) {
+        const patternInput = document.getElementById("pattern");
+        const patternFiles = patternInput.value ? patternInput.value.split(",").map(item => item.trim()) : [];
+
+        if (element.textContent.includes("Directory structure:")) {
+            return;
+        }
+
+        element.classList.toggle('line-through');
+        element.classList.toggle('text-gray-500');
+        
+        const fileName = getFileName(element.textContent);
+        const fileIndex = patternFiles.indexOf(fileName);
+
+        if (fileIndex !== -1) {
+            patternFiles.splice(fileIndex, 1);
+        } else {
+            patternFiles.push(fileName);
+        }
+
+        patternInput.value = patternFiles.join(", ");
+    }
+</script>
 {% if result %}
     <div class="mt-10" data-results>
         <div class="relative">
@@ -61,8 +91,11 @@
                         </div>
                         <div class="relative">
                             <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0"></div>
-                            <textarea class="directory-structure w-full p-4 bg-[#fff4da] border-[3px] border-gray-900 rounded font-mono text-sm resize-y focus:outline-none relative z-10 h-[215px]"
-                                      readonly>{{ tree }}</textarea>
+                            <div class="directory-structure w-full p-4 bg-[#fff4da] border-[3px] border-gray-900 rounded font-mono text-sm resize-y focus:outline-none relative z-10 h-[215px] overflow-scroll" readonly>
+                                {% for line in tree.splitlines()%}
+                                    <div name="tree-line" class="cursor-pointer hover:line-through hover:text-gray-500" onclick="toggleFile(this)">{{ line }}</div>
+                                {% endfor %}
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/src/static/js/utils.js
+++ b/src/static/js/utils.js
@@ -1,11 +1,24 @@
 // Copy functionality
 function copyText(className) {
-    const textarea = document.querySelector('.' + className);
+    let textToCopy;
+
+    if (className === 'directory-structure') {
+        // For directory structure, get the hidden input value
+        const hiddenInput = document.getElementById('directory-structure-content');
+        if (!hiddenInput) return;
+        textToCopy = hiddenInput.value;
+    } else {
+        // For other elements, get the textarea value
+        const textarea = document.querySelector('.' + className);
+        if (!textarea) return;
+        textToCopy = textarea.value;
+    }
+
     const button = document.querySelector(`button[onclick="copyText('${className}')"]`);
-    if (!textarea || !button) return;
+    if (!button) return;
 
     // Copy text
-    navigator.clipboard.writeText(textarea.value)
+    navigator.clipboard.writeText(textToCopy)
         .then(() => {
             // Store original content
             const originalContent = button.innerHTML;
@@ -110,7 +123,7 @@ function handleSubmit(event, showLoading = false) {
 }
 
 function copyFullDigest() {
-    const directoryStructure = document.querySelector('.directory-structure').value;
+    const directoryStructure = document.getElementById('directory-structure-content').value;
     const filesContent = document.querySelector('.result-text').value;
     const fullDigest = `${directoryStructure}\n\nFiles Content:\n\n${filesContent}`;
     const button = document.querySelector('[onclick="copyFullDigest()"]');


### PR DESCRIPTION
Made a couple of changes to finish the feature:
* Added some javascript code in `result.jinja` to add or remove file names to the patter input.
* Placed an `onchange` handler on the pattern selector to change CSS classes depending on whether "exclude" or "include" is selected. The simplest way to do this was to toggle all the classes, since it handles already selected files as well without any extra logic.

@cyclotruc feel free to let me know what you think! You also mentioned wanting to add some kind of notice to users that the items were clickable - do you think adding some text above the file tree would be the best way to do that?