### PR TITLE
Added latin as an encoding

### DIFF
--- a/src/gitingest/query_ingestion.py
+++ b/src/gitingest/query_ingestion.py
@@ -69,7 +69,7 @@ def _get_encoding_list() -> list[str]:
         List of encoding names to try in priority order, starting with the
         platform's default encoding followed by common fallback encodings.
     """
-    encodings = ["utf-8", "utf-8-sig"]
+    encodings = ["utf-8", "utf-8-sig", "latin"]
     if platform.system() == "Windows":
         encodings.extend(["cp1252", "iso-8859-1"])
     return encodings + [locale.getpreferredencoding()]


### PR DESCRIPTION
Added latin as an encoding, it fails to work with french characters without this. We don't all write good english. I had this issue because I got the error message below.

`
gitingest .
Error: 'charmap' codec can't encode characters in position 22-24: character maps to <undefined>
Aborted!
`

Now it works great.