### PR TITLE
fix: Fix MacOS path resolution failures and surface temp directory cleanup errors

### DIFF
--- a/src/gitingest/query_ingestion.py
+++ b/src/gitingest/query_ingestion.py
@@ -897,6 +897,6 @@ def run_ingest_query(query: ParsedQuery) -> Tuple[str, str, str]:
         raise ValueError(f"{query.slug} cannot be found")
 
     if query.type and query.type == "blob":
-        return _ingest_single_file(_normalize_path(path.resolve()), query)
+        return _ingest_single_file(path, query)
 
-    return _ingest_directory(_normalize_path(path.resolve()), query)
+    return _ingest_directory(path, query)

--- a/src/gitingest/repository_ingest.py
+++ b/src/gitingest/repository_ingest.py
@@ -96,7 +96,7 @@ async def ingest_async(
         # Clean up the temporary directory if it was created
         if parsed_query.url:
             # Clean up the temporary directory
-            shutil.rmtree(TMP_BASE_PATH, ignore_errors=True)
+            shutil.rmtree(TMP_BASE_PATH)
 
 
 def ingest(


### PR DESCRIPTION
- Removes the redundant `_normalize_path(path.resolve())` calls in `query_ingestion.py`, 
which were causing ingestion to fail on MacOS.
  - **Resolves**:
    - https://github.com/cyclotruc/gitingest/issues/179
    - https://github.com/cyclotruc/gitingest/issues/182)

- Removes `ignore_errors=True` from `shutil.rmtree` to enable error handling during temporary directory cleanup.
