### PR TITLE
feat(cli):Add support for .gitingest file processing in query ingestion

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -102,6 +102,7 @@ repos:
             slowapi,
             starlette,
             tiktoken,
+            tomli,
             uvicorn,
           ]
       - id: pylint
@@ -118,6 +119,7 @@ repos:
             python-dotenv,
             slowapi,
             starlette,
+            tomli,
             tiktoken,
             uvicorn,
           ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ python-dotenv
 slowapi
 starlette
 tiktoken
+tomli
 uvicorn

--- a/src/gitingest/query_ingestion.py
+++ b/src/gitingest/query_ingestion.py
@@ -918,28 +918,53 @@ def apply_gitingest_file(path: Path, query: ParsedQuery) -> None:
         The path of the directory to ingest.
     query : ParsedQuery
         The parsed query object containing information about the repository and query parameters.
+        It should have an attribute `ignore_patterns` which is either None or a set of strings.
     """
     path_gitingest = path / ".gitingest"
 
     if not path_gitingest.is_file():
-        # .gitingest doesn't exist or is not a regular file; nothing to do
         return
 
     try:
         with path_gitingest.open("rb") as f:
             data = tomli.load(f)
     except tomli.TOMLDecodeError as exc:
-        warnings.warn(f"Invalid TOML in {path_gitingest}: {exc}")
+        warnings.warn(f"Invalid TOML in {path_gitingest}: {exc}", UserWarning)
         return
 
-    # Safely grab the "config" section if present
     config_section = data.get("config", {})
     ignore_patterns = config_section.get("ignore_patterns")
 
-    if ignore_patterns:
-        if query.ignore_patterns is None:
-            query.ignore_patterns = set(ignore_patterns)
-        else:
-            query.ignore_patterns.update(ignore_patterns)
+    if not ignore_patterns:
+        return
+
+    # If a single string is provided, make it a list of one element
+    if isinstance(ignore_patterns, str):
+        ignore_patterns = [ignore_patterns]
+
+    if not isinstance(ignore_patterns, (list, set)):
+        warnings.warn(
+            f"Expected a list/set for 'ignore_patterns', got {type(ignore_patterns)} in {path_gitingest}. Skipping.",
+            UserWarning,
+        )
+        return
+
+    # Filter out duplicated patterns
+    ignore_patterns = set(ignore_patterns)
+
+    # Filter out any non-string entries
+    valid_patterns = {pattern for pattern in ignore_patterns if isinstance(pattern, str)}
+    invalid_patterns = ignore_patterns - valid_patterns
+
+    if invalid_patterns:
+        warnings.warn(f"Ignore patterns {invalid_patterns} are not strings. Skipping.", UserWarning)
+
+    if not valid_patterns:
+        return
+
+    if query.ignore_patterns is None:
+        query.ignore_patterns = valid_patterns
+    else:
+        query.ignore_patterns.update(valid_patterns)
 
     return

--- a/src/gitingest/query_ingestion.py
+++ b/src/gitingest/query_ingestion.py
@@ -935,5 +935,3 @@ def apply_gitingest_file(path: Path, query: ParsedQuery) -> None:
             print("No additional include patterns found in .gitingest file")
     else:
         print("No config found in .gitingest file")
-
-    return

--- a/src/gitingest/query_ingestion.py
+++ b/src/gitingest/query_ingestion.py
@@ -927,5 +927,13 @@ def apply_gitingest_file(path: Path, query: ParsedQuery) -> None:
         return
     with open(path_gitingest, "rb") as f:
         data = tomllib.load(f)
-    query.ignore_patterns.update(data["config"]["ignore_patterns"])
+    if "config" in data:
+        if "ignore_patterns" in data["config"]:
+            query.ignore_patterns.update(data["config"]["ignore_patterns"])
+            print(f"{data["config"]['ignore_patterns']} added to ignore patterns")
+        else:
+            print("No additional include patterns found in .gitingest file")
+    else:
+        print("No config found in .gitingest file")
+
     return

--- a/src/gitingest/query_ingestion.py
+++ b/src/gitingest/query_ingestion.py
@@ -3,6 +3,7 @@
 import locale
 import os
 import platform
+import tomllib
 from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
@@ -898,5 +899,33 @@ def run_ingest_query(query: ParsedQuery) -> Tuple[str, str, str]:
 
     if query.type and query.type == "blob":
         return _ingest_single_file(path, query)
-
+    apply_gitingest_file(path, query)
     return _ingest_directory(path, query)
+
+
+def apply_gitingest_file(path: Path, query: ParsedQuery) -> None:
+    """
+    Apply the .gitingest file to the query object.
+
+    This function reads the .gitingest file in the specified path and updates the query object
+    with the ignore patterns found in the file.
+
+    Parameters
+    ----------
+    path : Path
+        The path of the directory to ingest.
+    query : ParsedQuery
+        The parsed query object containing information about the repository and query parameters.
+
+    Returns
+    -------
+    None
+
+    """
+    path_gitingest = path / ".gitingest"
+    if not path_gitingest.exists():
+        return
+    with open(path_gitingest, "rb") as f:
+        data = tomllib.load(f)
+    query.ignore_patterns.update(data["config"]["ignore_patterns"])
+    return


### PR DESCRIPTION
# Feature Documentation: .gitingest Ignore Patterns

This pull request includes changes to the `src/gitingest/query_ingestion.py` file to enhance the query ingestion process by applying ignore patterns from a `.gitingest` file. The most important changes include importing the `tomllib` library and adding a new function to handle the `.gitingest` file.

Enhancements to query ingestion:

* [`src/gitingest/query_ingestion.py`](diffhunk://#diff-1b2905ac9d245e3923885fa9fd5aa435537ed4c9998e22ac2d0777006628633cR6): Imported the `tomllib` library to read TOML files.
* [`src/gitingest/query_ingestion.py`](diffhunk://#diff-1b2905ac9d245e3923885fa9fd5aa435537ed4c9998e22ac2d0777006628633cL901-R931): Added the `apply_gitingest_file` function to read the `.gitingest` file and update the query object with ignore patterns.

## Overview
This feature introduces support for a `.gitingest` configuration file in the project root directory that allows users to define file and directory ignore patterns using a TOML format. The `.gitingest` file enables more flexible and customizable query ingestion by allowing users to exclude specific files or directories from being processed.

## Purpose
The primary goal of this feature is to provide users with a simple and effective way to define ignore patterns for files and directories that should not be ingested by the query ingestion process. This reduces unnecessary processing, improves performance, and allows for better control over the indexing of repository contents.

## File Format
The `.gitingest` file is written in TOML format and consists of a `[config]` section where users specify ignore patterns as a list.

### Example `.gitingest` File:
```toml
[config]
ignore_patterns = ["README.md", "tests/", "*.log", "docs/*.md"]
```

### Explanation of Fields:
- **ignore_patterns**: A list of file paths, directory paths, or glob patterns that define which files should be excluded from ingestion.
  - Specific file names (e.g., `README.md`) will be ignored.
  - Directory names (e.g., `tests/`) will cause all files inside the directory to be ignored.
  - Wildcard patterns (e.g., `*.log`) allow for flexible filtering of file types.
  - Path-based patterns (e.g., `docs/*.md`) allow filtering within specific subdirectories.

## Future Enhancements
- Support for negation rules (e.g., exclude everything except a specific file type).
-  Support for inclusion rules (e.g., exclude everything except a specific file type).
- Allow `.gitingest` to be placed in subdirectories for more granular control.
- Writing tests for the .gitingest file working.

By implementing the `.gitingest` file support, this feature significantly improves the usability and efficiency of the query ingestion system in `gitingest`.