### PR TITLE
feat: tags and their subdirectories can be fetched

### DIFF
--- a/src/gitingest/cli.py
+++ b/src/gitingest/cli.py
@@ -18,6 +18,7 @@ from gitingest.repository_ingest import ingest_async
 @click.option("--exclude-pattern", "-e", multiple=True, help="Patterns to exclude")
 @click.option("--include-pattern", "-i", multiple=True, help="Patterns to include")
 @click.option("--branch", "-b", default=None, help="Branch to clone and ingest")
+@click.option("--tag", "-t", default=None, help="Tag to clone and ingest")
 @click.option("--include-submodules", is_flag=True, help="Include git submodules in the analysis")
 def main(
     source: str,
@@ -26,6 +27,7 @@ def main(
     exclude_pattern: Tuple[str, ...],
     include_pattern: Tuple[str, ...],
     branch: Optional[str],
+    tag: Optional[str],
     include_submodules: bool,
 ):
     """
@@ -48,11 +50,24 @@ def main(
         A tuple of patterns to include during the analysis. Only files matching these patterns will be processed.
     branch : str, optional
         The branch to clone (optional).
+    tag : str, optional
+        The tag to clone (optional).
     include_submodules : bool
         Whether to include git submodules in the analysis.
     """
     # Main entry point for the CLI. This function is called when the CLI is run as a script.
-    asyncio.run(_async_main(source, output, max_size, exclude_pattern, include_pattern, branch, include_submodules))
+    asyncio.run(
+        _async_main(
+            source=source,
+            output=output,
+            max_size=max_size,
+            exclude_pattern=exclude_pattern,
+            include_pattern=include_pattern,
+            branch=branch,
+            tag=tag,
+            include_submodules=include_submodules,
+        )
+    )
 
 
 async def _async_main(
@@ -62,6 +77,7 @@ async def _async_main(
     exclude_pattern: Tuple[str, ...],
     include_pattern: Tuple[str, ...],
     branch: Optional[str],
+    tag: Optional[str],
     include_submodules: bool,
 ) -> None:
     """
@@ -85,6 +101,8 @@ async def _async_main(
         A tuple of patterns to include during the analysis. Only files matching these patterns will be processed.
     branch : str, optional
         The branch to clone (optional).
+    tag : str, optional
+        The tag to clone (optional).
     include_submodules : bool
         Whether to include git submodules in the analysis.
 
@@ -100,7 +118,9 @@ async def _async_main(
 
         if not output:
             output = OUTPUT_FILE_NAME
-        summary, _, _ = await ingest_async(source, max_size, include_patterns, exclude_patterns, branch, include_submodules, output=output)
+        summary, _, _ = await ingest_async(
+            source, max_size, include_patterns, exclude_patterns, include_submodules, branch, tag, output=output
+        )
 
         click.echo(f"Analysis complete! Output written to: {output}")
         click.echo("\nSummary:")

--- a/src/gitingest/cli.py
+++ b/src/gitingest/cli.py
@@ -18,6 +18,7 @@ from gitingest.repository_ingest import ingest_async
 @click.option("--exclude-pattern", "-e", multiple=True, help="Patterns to exclude")
 @click.option("--include-pattern", "-i", multiple=True, help="Patterns to include")
 @click.option("--branch", "-b", default=None, help="Branch to clone and ingest")
+@click.option("--include-submodules", is_flag=True, help="Include git submodules in the analysis")
 def main(
     source: str,
     output: Optional[str],
@@ -25,6 +26,7 @@ def main(
     exclude_pattern: Tuple[str, ...],
     include_pattern: Tuple[str, ...],
     branch: Optional[str],
+    include_submodules: bool,
 ):
     """
      Main entry point for the CLI. This function is called when the CLI is run as a script.
@@ -46,9 +48,11 @@ def main(
         A tuple of patterns to include during the analysis. Only files matching these patterns will be processed.
     branch : str, optional
         The branch to clone (optional).
+    include_submodules : bool
+        Whether to include git submodules in the analysis.
     """
     # Main entry point for the CLI. This function is called when the CLI is run as a script.
-    asyncio.run(_async_main(source, output, max_size, exclude_pattern, include_pattern, branch))
+    asyncio.run(_async_main(source, output, max_size, exclude_pattern, include_pattern, branch, include_submodules))
 
 
 async def _async_main(
@@ -58,6 +62,7 @@ async def _async_main(
     exclude_pattern: Tuple[str, ...],
     include_pattern: Tuple[str, ...],
     branch: Optional[str],
+    include_submodules: bool,
 ) -> None:
     """
     Analyze a directory or repository and create a text dump of its contents.
@@ -80,6 +85,8 @@ async def _async_main(
         A tuple of patterns to include during the analysis. Only files matching these patterns will be processed.
     branch : str, optional
         The branch to clone (optional).
+    include_submodules : bool
+        Whether to include git submodules in the analysis.
 
     Raises
     ------
@@ -93,7 +100,7 @@ async def _async_main(
 
         if not output:
             output = OUTPUT_FILE_NAME
-        summary, _, _ = await ingest_async(source, max_size, include_patterns, exclude_patterns, branch, output=output)
+        summary, _, _ = await ingest_async(source, max_size, include_patterns, exclude_patterns, branch, include_submodules, output=output)
 
         click.echo(f"Analysis complete! Output written to: {output}")
         click.echo("\nSummary:")

--- a/src/gitingest/ingestion.py
+++ b/src/gitingest/ingestion.py
@@ -72,9 +72,7 @@ def ingest_query(query: ParsedQuery) -> Tuple[str, str, str]:
         stats=stats,
     )
 
-
     return format_directory(root_node, query)
-
 
 
 def _process_node(
@@ -90,18 +88,21 @@ def _process_node(
 
     Parameters
     ----------
-    path : Path
-        The full path of the file or directory to process.
+    node : FileSystemNode
+        The node representing the file or directory to process.
     query : ParsedQuery
         The parsed query object containing information about the repository and query parameters.
-    node : FileSystemNode
-        The current directory or file node being processed.
-    seen_paths : Set[Path]
-        A set of paths that have already been visited.
-    stats : Dict[str, int]
-        A dictionary of statistics like the total file count and size.
-    depth : int
-        The current depth of directory traversal.
+    stats : FileSystemStats
+        Statistics object to track file counts and sizes.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    ValueError
+        If the node type is not recognized.
     """
 
     if limit_exceeded(stats, node.depth):
@@ -141,7 +142,7 @@ def _process_node(
                 path=sub_path,
                 depth=node.depth + 1,
             )
-            
+
             # rename the subdir to reflect the symlink name
             if symlink_path:
                 child_directory_node.name = symlink_path.name
@@ -176,8 +177,10 @@ def _process_file(path: Path, parent_node: FileSystemNode, stats: FileSystemStat
         The full path of the file.
     parent_node : FileSystemNode
         The dictionary to accumulate the results.
-    stats : Dict[str, int]
-        The dictionary to track statistics such as file count and size.
+    stats : FileSystemStats
+        Statistics object to track file counts and sizes.
+    local_path : Path
+        The local path relative to the repository root.
     """
     file_size = path.stat().st_size
     if stats.total_size + file_size > MAX_TOTAL_SIZE_BYTES:
@@ -198,7 +201,7 @@ def _process_file(path: Path, parent_node: FileSystemNode, stats: FileSystemStat
         file_count=1,
         path_str=str(path.relative_to(local_path)),
         path=path,
-        depth=parent_node.depth + 1
+        depth=parent_node.depth + 1,
     )
 
     parent_node.children.append(child)
@@ -207,7 +210,24 @@ def _process_file(path: Path, parent_node: FileSystemNode, stats: FileSystemStat
 
 
 def limit_exceeded(stats: FileSystemStats, depth: int) -> bool:
+    """
+    Check if any of the processing limits have been exceeded.
 
+    This function checks if the current processing has exceeded any of the defined limits:
+    maximum directory depth, maximum number of files, or maximum total size.
+
+    Parameters
+    ----------
+    stats : FileSystemStats
+        The current statistics object tracking file counts and sizes.
+    depth : int
+        The current depth in the directory tree.
+
+    Returns
+    -------
+    bool
+        True if any limit has been exceeded, False otherwise.
+    """
     if depth > MAX_DIRECTORY_DEPTH:
         print(f"Maximum depth limit ({MAX_DIRECTORY_DEPTH}) reached")
         return True

--- a/src/gitingest/repository_ingest.py
+++ b/src/gitingest/repository_ingest.py
@@ -3,7 +3,7 @@
 import asyncio
 import inspect
 import shutil
-from typing import List, Optional, Set, Tuple, Union
+from typing import Optional, Set, Tuple, Union
 
 from gitingest.cloning import CloneConfig, clone_repo
 from gitingest.config import TMP_BASE_PATH
@@ -18,6 +18,7 @@ async def ingest_async(
     exclude_patterns: Optional[Union[str, Set[str]]] = None,
     include_submodules: bool = False,
     branch: Optional[str] = None,
+    tag: Optional[str] = None,
     output: Optional[str] = None,
 ) -> Tuple[str, str, str]:
     """
@@ -42,6 +43,8 @@ async def ingest_async(
         Whether to include git submodules in the analysis. Defaults to False.
     branch : str, optional
         The branch to clone and ingest. If `None`, the default branch is used.
+    tag : str, optional
+        The tag to clone and ingest. If `None`, tag is not used.
     output : str, optional
         File path where the summary and content should be written. If `None`, the results are not written to a file.
 
@@ -72,15 +75,16 @@ async def ingest_async(
         )
 
         if parsed_query.url:
-            selected_branch = branch if branch else parsed_query.branch  # prioritize branch argument
-            parsed_query.branch = selected_branch
+            parsed_query.branch = branch or parsed_query.branch
+            parsed_query.tag = tag or parsed_query.tag
 
             # Extract relevant fields for CloneConfig
             clone_config = CloneConfig(
                 url=parsed_query.url,
                 local_path=str(parsed_query.local_path),
                 commit=parsed_query.commit,
-                branch=selected_branch,
+                branch=parsed_query.branch,
+                tag=parsed_query.tag,
                 include_submodules=include_submodules,
             )
             clone_coroutine = clone_repo(clone_config)
@@ -115,6 +119,7 @@ def ingest(
     exclude_patterns: Optional[Union[str, Set[str]]] = None,
     include_submodules: bool = False,
     branch: Optional[str] = None,
+    tag: Optional[str] = None,
     output: Optional[str] = None,
 ) -> Tuple[str, str, str]:
     """
@@ -139,6 +144,8 @@ def ingest(
         Whether to include git submodules in the analysis. Defaults to False.
     branch : str, optional
         The branch to clone and ingest. If `None`, the default branch is used.
+    tag : str, optional
+        The tag to clone and ingest. If `None`, tag is not used.
     output : str, optional
         File path where the summary and content should be written. If `None`, the results are not written to a file.
 
@@ -162,6 +169,7 @@ def ingest(
             exclude_patterns=exclude_patterns,
             include_submodules=include_submodules,
             branch=branch,
+            tag=tag,
             output=output,
         )
     )

--- a/src/gitingest/repository_ingest.py
+++ b/src/gitingest/repository_ingest.py
@@ -3,7 +3,7 @@
 import asyncio
 import inspect
 import shutil
-from typing import Optional, Set, Tuple, Union
+from typing import List, Optional, Set, Tuple, Union
 
 from gitingest.cloning import CloneConfig, clone_repo
 from gitingest.config import TMP_BASE_PATH
@@ -16,6 +16,7 @@ async def ingest_async(
     max_file_size: int = 10 * 1024 * 1024,  # 10 MB
     include_patterns: Optional[Union[str, Set[str]]] = None,
     exclude_patterns: Optional[Union[str, Set[str]]] = None,
+    include_submodules: bool = False,
     branch: Optional[str] = None,
     output: Optional[str] = None,
 ) -> Tuple[str, str, str]:
@@ -37,10 +38,13 @@ async def ingest_async(
         Pattern or set of patterns specifying which files to include. If `None`, all files are included.
     exclude_patterns : Union[str, Set[str]], optional
         Pattern or set of patterns specifying which files to exclude. If `None`, no files are excluded.
+    include_submodules : bool
+        Whether to include git submodules in the analysis. Defaults to False.
     branch : str, optional
         The branch to clone and ingest. If `None`, the default branch is used.
     output : str, optional
         File path where the summary and content should be written. If `None`, the results are not written to a file.
+
 
     Returns
     -------
@@ -64,6 +68,7 @@ async def ingest_async(
             from_web=False,
             include_patterns=include_patterns,
             ignore_patterns=exclude_patterns,
+            include_submodules=include_submodules,
         )
 
         if parsed_query.url:
@@ -76,6 +81,7 @@ async def ingest_async(
                 local_path=str(parsed_query.local_path),
                 commit=parsed_query.commit,
                 branch=selected_branch,
+                include_submodules=include_submodules,
             )
             clone_coroutine = clone_repo(clone_config)
 
@@ -107,6 +113,7 @@ def ingest(
     max_file_size: int = 10 * 1024 * 1024,  # 10 MB
     include_patterns: Optional[Union[str, Set[str]]] = None,
     exclude_patterns: Optional[Union[str, Set[str]]] = None,
+    include_submodules: bool = False,
     branch: Optional[str] = None,
     output: Optional[str] = None,
 ) -> Tuple[str, str, str]:
@@ -128,6 +135,8 @@ def ingest(
         Pattern or set of patterns specifying which files to include. If `None`, all files are included.
     exclude_patterns : Union[str, Set[str]], optional
         Pattern or set of patterns specifying which files to exclude. If `None`, no files are excluded.
+    include_submodules : bool
+        Whether to include git submodules in the analysis. Defaults to False.
     branch : str, optional
         The branch to clone and ingest. If `None`, the default branch is used.
     output : str, optional
@@ -151,6 +160,7 @@ def ingest(
             max_file_size=max_file_size,
             include_patterns=include_patterns,
             exclude_patterns=exclude_patterns,
+            include_submodules=include_submodules,
             branch=branch,
             output=output,
         )

--- a/src/server/query_processor.py
+++ b/src/server/query_processor.py
@@ -94,6 +94,7 @@ async def process_query(
             local_path=str(parsed_query.local_path),
             commit=parsed_query.commit,
             branch=parsed_query.branch,
+            tag=parsed_query.tag,
             include_submodules=include_submodules,
         )
         await clone_repo(clone_config)

--- a/src/server/query_processor.py
+++ b/src/server/query_processor.py
@@ -18,6 +18,7 @@ async def process_query(
     slider_position: int,
     pattern_type: str = "exclude",
     pattern: str = "",
+    include_submodules: bool = False,
     is_index: bool = False,
 ) -> _TemplateResponse:
     """
@@ -38,6 +39,8 @@ async def process_query(
         Type of pattern to use, either "include" or "exclude" (default is "exclude").
     pattern : str
         Pattern to include or exclude in the query, depending on the pattern type.
+    include_submodules : bool
+        Flag indicating whether to include submodules in the query.
     is_index : bool
         Flag indicating whether the request is for the index page (default is False).
 
@@ -71,6 +74,7 @@ async def process_query(
         "default_file_size": slider_position,
         "pattern_type": pattern_type,
         "pattern": pattern,
+        "include_submodules": include_submodules,
     }
 
     try:
@@ -80,6 +84,7 @@ async def process_query(
             from_web=True,
             include_patterns=include_patterns,
             ignore_patterns=exclude_patterns,
+            include_submodules=include_submodules,
         )
         if not parsed_query.url:
             raise ValueError("The 'url' parameter is required.")
@@ -89,6 +94,7 @@ async def process_query(
             local_path=str(parsed_query.local_path),
             commit=parsed_query.commit,
             branch=parsed_query.branch,
+            include_submodules=include_submodules,
         )
         await clone_repo(clone_config)
         summary, tree, content = ingest_query(parsed_query)

--- a/src/server/routers/dynamic.py
+++ b/src/server/routers/dynamic.py
@@ -50,6 +50,7 @@ async def process_catch_all(
     max_file_size: int = Form(...),
     pattern_type: str = Form(...),
     pattern: str = Form(...),
+    include_submodules: bool = Form(False),
 ) -> HTMLResponse:
     """
     Process the form submission with user input for query parameters.
@@ -69,6 +70,8 @@ async def process_catch_all(
         The type of pattern used for the query, specified by the user.
     pattern : str
         The pattern string used in the query, specified by the user.
+    include_submodules : bool
+        Indicates whether to include submodules in the query.
 
     Returns
     -------
@@ -82,5 +85,6 @@ async def process_catch_all(
         max_file_size,
         pattern_type,
         pattern,
+        include_submodules=include_submodules,
         is_index=False,
     )

--- a/src/server/routers/index.py
+++ b/src/server/routers/index.py
@@ -47,6 +47,7 @@ async def index_post(
     max_file_size: int = Form(...),
     pattern_type: str = Form(...),
     pattern: str = Form(...),
+    include_submodules: bool = Form(False),
 ) -> HTMLResponse:
     """
     Process the form submission with user input for query parameters.
@@ -67,6 +68,8 @@ async def index_post(
         The type of pattern used for the query, specified by the user.
     pattern : str
         The pattern string used in the query, specified by the user.
+    include_submodules : bool
+        Indicates whether to include submodules in the query, specified by the user.
 
     Returns
     -------
@@ -80,5 +83,6 @@ async def index_post(
         max_file_size,
         pattern_type,
         pattern,
+        include_submodules=include_submodules,
         is_index=True,
     )

--- a/src/server/templates/components/git_form.jinja
+++ b/src/server/templates/components/git_form.jinja
@@ -17,6 +17,11 @@
             element.classList.toggle('hover:text-gray-500');
         });
     }
+
+    function updateSubmodulesValue(checkbox) {
+        const hiddenInput = document.querySelector('input[type="hidden"][name="include_submodules"]');
+        hiddenInput.value = checkbox.checked.toString();
+    }
 </script>
 <div class="relative">
     <div class="w-full h-full absolute inset-0 bg-gray-900 rounded-xl translate-y-2 translate-x-2"></div>
@@ -45,6 +50,7 @@
             </div>
             <input type="hidden" name="pattern_type" value="exclude">
             <input type="hidden" name="pattern" value="">
+            <input type="hidden" name="include_submodules" value="false">
         </form>
         <div class="mt-4 relative z-20 flex flex-wrap gap-4 items-start">
             <!-- Pattern selector -->
@@ -79,22 +85,53 @@
                                name="pattern"
                                placeholder="*.md, src/ "
                                value="{{ pattern if pattern else '' }}"
-                               class=" py-2 px-2 bg-[#E8F0FE] focus:outline-none w-full">
+                               class="py-2 px-2 bg-[#E8F0FE] focus:outline-none w-full">
                     </div>
                 </div>
             </div>
-            <div class="w-[200px] sm:w-[200px] mt-3">
-                <label for="file_size" class="block text-gray-700 mb-1">
-                    Include files under: <span id="size_value" class="font-bold">50kb</span>
-                </label>
-                <input type="range"
-                       id="file_size"
-                       name="max_file_size"
-                       min="0"
-                       max="500"
-                       required
-                       value="{{ default_file_size }}"
-                       class="w-full h-3 bg-[#FAFAFA] bg-no-repeat bg-[length:50%_100%] bg-[#ebdbb7] appearance-none border-[3px] border-gray-900 rounded-sm focus:outline-none bg-gradient-to-r from-[#FE4A60] to-[#FE4A60] [&::-webkit-slider-thumb]:w-5 [&::-webkit-slider-thumb]:h-7 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:rounded-sm [&::-webkit-slider-thumb]:cursor-pointer [&::-webkit-slider-thumb]:border-solid [&::-webkit-slider-thumb]:border-[3px] [&::-webkit-slider-thumb]:border-gray-900 [&::-webkit-slider-thumb]:shadow-[3px_3px_0_#000]  ">
+            <div class="flex flex-col gap-2">
+                <!-- File size slider -->
+                <div class="w-[200px] sm:w-[200px]">
+                    <label for="file_size" class="block text-gray-700 mb-1">
+                        Include files under: <span id="size_value" class="font-bold">50kb</span>
+                    </label>
+                    <input type="range"
+                           id="file_size"
+                           name="max_file_size"
+                           min="0"
+                           max="500"
+                           required
+                           value="{{ default_file_size }}"
+                           class="w-full h-3 bg-[#FAFAFA] bg-no-repeat bg-[length:50%_100%] bg-[#ebdbb7] appearance-none border-[3px] border-gray-900 rounded-sm focus:outline-none bg-gradient-to-r from-[#FE4A60] to-[#FE4A60] [&::-webkit-slider-thumb]:w-5 [&::-webkit-slider-thumb]:h-7 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:rounded-sm [&::-webkit-slider-thumb]:cursor-pointer [&::-webkit-slider-thumb]:border-solid [&::-webkit-slider-thumb]:border-[3px] [&::-webkit-slider-thumb]:border-gray-900 [&::-webkit-slider-thumb]:shadow-[3px_3px_0_#000]">
+                </div>
+                <!-- Submodules checkbox -->
+                <div class="w-[200px] sm:w-[200px] flex items-center mt-2">
+                    <div class="relative inline-block">
+                        <input type="checkbox"
+                               id="include_submodules"
+                               name="include_submodules"
+                               form="ingestForm"
+                               onchange="updateSubmodulesValue(this)"
+                               oninput="updateSubmodulesValue(this)"
+                               class="peer absolute opacity-0 w-5 h-5 cursor-pointer z-20">
+                        <div class="w-5 h-5 bg-gray-900 absolute translate-y-[3px] translate-x-[3px] rounded peer-checked:translate-y-[1px] peer-checked:translate-x-[1px] transition-transform duration-200">
+                        </div>
+                        <div class="w-5 h-5 border-[3px] border-gray-900 bg-[#fff4da] rounded relative peer-checked:bg-[#FE4A60] peer-focus:outline-none peer-checked:translate-y-[2px] peer-checked:translate-x-[2px] transition-all duration-200">
+                            <svg class="w-full h-full text-white hidden peer-checked:block p-[2px]"
+                                 xmlns="http://www.w3.org/2000/svg"
+                                 viewBox="0 0 24 24"
+                                 fill="none"
+                                 stroke="currentColor"
+                                 stroke-width="4"
+                                 stroke-linecap="round"
+                                 stroke-linejoin="round">
+                                <polyline points="20 6 9 17 4 12"></polyline>
+                            </svg>
+                        </div>
+                    </div>
+                    <label for="include_submodules"
+                           class="ml-2 text-gray-700 cursor-pointer select-none">Include submodules</label>
+                </div>
             </div>
         </div>
         {% if show_examples %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,7 @@ def sample_query() -> ParsedQuery:
         slug="test_user/test_repo",
         id="id",
         branch="main",
+        tag=None,
         max_file_size=1_000_000,
         ignore_patterns={"*.pyc", "__pycache__", ".git"},
         include_patterns=None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,7 @@ def sample_query() -> ParsedQuery:
         max_file_size=1_000_000,
         ignore_patterns={"*.pyc", "__pycache__", ".git"},
         include_patterns=None,
+        include_submodules=False,
         pattern_type="exclude",
     )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 """ Tests for the gitingest cli """
 
 import os
+from unittest.mock import patch
 
 from click.testing import CliRunner
 
@@ -32,6 +33,7 @@ def test_cli_with_options():
             "tests/",
             "--include-pattern",
             "src/",
+            "--include-submodules",
         ],
     )
     output_lines = result.output.strip().split("\n")
@@ -39,3 +41,34 @@ def test_cli_with_options():
     assert os.path.exists(OUTPUT_FILE_NAME), f"Output file was not created at {OUTPUT_FILE_NAME}"
 
     os.remove(OUTPUT_FILE_NAME)
+
+
+def test_cli_submodules_flag():
+    """Test that the --include-submodules flag works correctly."""
+    runner = CliRunner()
+    with patch("gitingest.cli._async_main") as mock_async_main:
+        # Test with flag
+        result = runner.invoke(main, ["./", "--include-submodules"])
+        assert result.exit_code == 0
+        mock_async_main.assert_called_with(
+            "./",
+            None,
+            10485760,
+            (),
+            (),
+            None,
+            True,  # include_submodules
+        )
+
+        # Test without flag
+        result = runner.invoke(main, ["./"])
+        assert result.exit_code == 0
+        mock_async_main.assert_called_with(
+            "./",
+            None,
+            10485760,
+            (),
+            (),
+            None,
+            False,  # include_submodules
+        )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -72,3 +72,31 @@ def test_cli_submodules_flag():
             None,
             False,  # include_submodules
         )
+
+
+def test_cli_tag_option():
+    """Test that the --tag flag works correctly."""
+    runner = CliRunner()
+    with patch("gitingest.cli._async_main") as mock_async_main:
+        # Test with tag option
+        result = runner.invoke(main, ["./", "--tag", "v1.0.0"])
+        assert result.exit_code == 0
+        mock_async_main.assert_called_with(
+            source="./",
+            output=None,
+            max_size=10485760,
+            exclude_pattern=(),
+            include_pattern=(),
+            branch=None,
+            tag="v1.0.0",
+            include_submodules=False,
+        )
+
+
+def test_cli_tag_and_branch_conflict():
+    """Test that specifying both tag and branch raises an error."""
+    runner = CliRunner()
+    with patch("gitingest.cli.ingest_async", side_effect=ValueError("Cannot specify both branch and tag")):
+        result = runner.invoke(main, ["./", "--tag", "v1.0.0", "--branch", "main"])
+        assert result.exit_code != 0
+        assert "Error: Cannot specify both branch and tag" in result.output

--- a/tests/test_flow_integration.py
+++ b/tests/test_flow_integration.py
@@ -157,3 +157,37 @@ async def test_repository_with_patterns(request):
     response = client.post("/", data=form_data)
     assert response.status_code == 200, f"Request failed: {response.text}"
     assert "Mocked Template Response" in response.text
+
+
+@pytest.mark.asyncio
+async def test_repository_with_submodules(request):
+    """Test repository analysis with submodules enabled."""
+    client = request.getfixturevalue("test_client")
+    form_data = {
+        "input_text": "https://github.com/octocat/Hello-World",
+        "max_file_size": "243",
+        "pattern_type": "exclude",
+        "pattern": "",
+        "include_submodules": "true",
+    }
+
+    response = client.post("/", data=form_data)
+    assert response.status_code == 200, f"Request failed: {response.text}"
+    assert "Mocked Template Response" in response.text
+
+
+@pytest.mark.asyncio
+async def test_repository_without_submodules(request):
+    """Test repository analysis with submodules disabled."""
+    client = request.getfixturevalue("test_client")
+    form_data = {
+        "input_text": "https://github.com/octocat/Hello-World",
+        "max_file_size": "243",
+        "pattern_type": "exclude",
+        "pattern": "",
+        "include_submodules": "false",
+    }
+
+    response = client.post("/", data=form_data)
+    assert response.status_code == 200, f"Request failed: {response.text}"
+    assert "Mocked Template Response" in response.text

--- a/tests/test_query_parsing.py
+++ b/tests/test_query_parsing.py
@@ -5,6 +5,8 @@ These tests verify that the query parsing module correctly handles various input
 including the submodules flag, and produces appropriate ParsedQuery objects.
 """
 
+from unittest.mock import patch
+
 import pytest
 
 from gitingest.query_parsing import parse_query
@@ -24,3 +26,49 @@ async def test_parse_query_without_submodules():
     """Test that parse_query defaults to not including submodules."""
     parsed = await parse_query(source="https://github.com/user/repo", max_file_size=1000, from_web=True)
     assert parsed.include_submodules is False
+
+
+@pytest.mark.asyncio
+async def test_parse_query_with_tag():
+    """Test that parse_query correctly handles tag parameter."""
+    with patch("gitingest.query_parsing.fetch_remote_branch_list") as mock_branch_list:
+        with patch("gitingest.query_parsing.fetch_remote_tag_list") as mock_tag_list:
+            mock_branch_list.return_value = []  # No matching branch
+            mock_tag_list.return_value = ["v1.0.0"]  # Tag exists
+
+            parsed = await parse_query(
+                source="https://github.com/user/repo/tree/v1.0.0", max_file_size=1000, from_web=True
+            )
+            assert parsed.tag == "v1.0.0"
+            assert parsed.branch is None
+            assert parsed.commit is None
+
+
+@pytest.mark.asyncio
+async def test_parse_query_tag_priority():
+    """Test that branch is prioritized over tag when both could match."""
+    with patch("gitingest.query_parsing.fetch_remote_branch_list") as mock_branch_list:
+        with patch("gitingest.query_parsing.fetch_remote_tag_list") as mock_tag_list:
+            mock_branch_list.return_value = ["v1.0.0"]  # Same name exists as branch
+            mock_tag_list.return_value = ["v1.0.0"]  # Same name exists as tag
+
+            parsed = await parse_query(
+                source="https://github.com/user/repo/tree/v1.0.0", max_file_size=1000, from_web=True
+            )
+            assert parsed.branch == "v1.0.0"  # Branch should be chosen over tag
+            assert parsed.tag is None
+
+
+@pytest.mark.asyncio
+async def test_parse_query_tag_fallback():
+    """Test that tag is used when branch doesn't exist."""
+    with patch("gitingest.query_parsing.fetch_remote_branch_list") as mock_branch_list:
+        with patch("gitingest.query_parsing.fetch_remote_tag_list") as mock_tag_list:
+            mock_branch_list.return_value = []  # No matching branch
+            mock_tag_list.return_value = ["v1.0.0"]  # Tag exists
+
+            parsed = await parse_query(
+                source="https://github.com/user/repo/tree/v1.0.0", max_file_size=1000, from_web=True
+            )
+            assert parsed.branch is None
+            assert parsed.tag == "v1.0.0"

--- a/tests/test_query_parsing.py
+++ b/tests/test_query_parsing.py
@@ -1,0 +1,26 @@
+"""
+Tests for the query parsing functionality.
+
+These tests verify that the query parsing module correctly handles various input parameters,
+including the submodules flag, and produces appropriate ParsedQuery objects.
+"""
+
+import pytest
+
+from gitingest.query_parsing import parse_query
+
+
+@pytest.mark.asyncio
+async def test_parse_query_with_submodules():
+    """Test that parse_query correctly handles include_submodules parameter."""
+    parsed = await parse_query(
+        source="https://github.com/user/repo", max_file_size=1000, from_web=True, include_submodules=True
+    )
+    assert parsed.include_submodules is True
+
+
+@pytest.mark.asyncio
+async def test_parse_query_without_submodules():
+    """Test that parse_query defaults to not including submodules."""
+    parsed = await parse_query(source="https://github.com/user/repo", max_file_size=1000, from_web=True)
+    assert parsed.include_submodules is False


### PR DESCRIPTION
Additional Features Building on #203 (*See https://github.com/cyclotruc/gitingest/pull/203*)
(I can make a new PR if you confirm and merge #203)


This PR extends the previous work by adding support for fetching and recognizing tags, along with their subdirectories. 
(history: https://github.com/cyclotruc/gitingest/issues/196)

### Features:
- Tag Options for CLI: Added --tag and -t flags.
     - If both branch and tag names are specified, the process will abort to avoid confusion.
- Tag Fetching: Now fetches repository tags in addition to branches.
     - Branch names take priority over tag names to handle cases where they’re names are identical. (This logic could be revisited in future updates if needed.)
- Tests: Added new test cases to cover the changes.
- Miscellaneous: Includes some minor tweaks to satisfy pre-commit checks.

<br>

### Examples

**Web Interface**

|  |
|--------------------|
| ![Without Submodules - Tree](https://github.com/user-attachments/assets/1885aeaf-5daf-45dc-8beb-666debc8659e) 
| ![With Submodules - Tree](https://github.com/user-attachments/assets/a13b3b1b-e008-477a-ac63-8f484b28502c) |



**CLI Examples**

```bash
❯ gitingest https://github.com/cyclotruc/gitingest/tree/v0.1.3/src/gitingest
Analysis complete! Output written to: digest.txt

Summary:
Repository: cyclotruc/gitingest
Tag: v0.1.3
Subpath: /src/gitingest
Files analyzed: 11

Estimated tokens: 16.5k
```


```bash
❯ gitingest https://github.com/pytorch/pytorch/tree/v2.4.1/torch/distributed/elastic
Analysis complete! Output written to: digest.txt

Summary:
Repository: pytorch/pytorch
Tag: v2.4.1
Subpath: /torch/distributed/elastic
Files analyzed: 47

Estimated tokens: 79.0k
```