### PR TITLE
fix: fix directory include pattern matching and normalize Windows paths

### DIFF
--- a/src/gitingest/ingestion.py
+++ b/src/gitingest/ingestion.py
@@ -12,7 +12,7 @@ from gitingest.utils.ingestion_utils import _should_exclude, _should_include
 from gitingest.utils.path_utils import _is_safe_symlink
 
 try:
-    import tomllib
+    import tomllib  # type: ignore[import]
 except ImportError:
     import tomli as tomllib
 

--- a/src/gitingest/query_parsing.py
+++ b/src/gitingest/query_parsing.py
@@ -296,6 +296,9 @@ def _parse_patterns(pattern: Union[str, Set[str]]) -> Set[str]:
     # Remove empty string if present
     parsed_patterns = parsed_patterns - {""}
 
+    # Normalize Windows paths to Unix-style paths
+    parsed_patterns = {p.replace("\\", "/") for p in parsed_patterns}
+
     # Validate and normalize each pattern
     for p in parsed_patterns:
         if not _is_valid_pattern(p):

--- a/src/gitingest/utils/ingestion_utils.py
+++ b/src/gitingest/utils/ingestion_utils.py
@@ -56,6 +56,9 @@ def _should_include(path: Path, base_path: Path, include_patterns: Set[str]) -> 
         return False
 
     rel_str = str(rel_path)
+    if path.is_dir():
+        rel_str += "/"
+
     for pattern in include_patterns:
         if fnmatch(rel_str, pattern):
             return True


### PR DESCRIPTION
This PR introduces improvements to cross-platform path handling and directory inclusion:

1. **Windows Path Normalization**  
   Backslashes are now converted to forward slashes in `_parse_patterns`, ensuring consistent pattern matching on Windows, macOS, and Linux.

2. **Directory Include Pattern Handling**  
   If the path is a directory, a trailing slash is appended (e.g., `src/`), so that patterns like `src/*` properly match directories.


- **Fixes**: https://github.com/cyclotruc/gitingest/issues/205