### PR TITLE
Fix/dirtree

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gitingest"
-version = "0.1.4"
+version = "0.1.3"
 description="CLI tool to analyze and create text dumps of codebases for LLMs"
 readme = {file = "README.md", content-type = "text/markdown" }
 requires-python = ">= 3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gitingest"
-version = "0.1.3"
+version = "0.1.4"
 description="CLI tool to analyze and create text dumps of codebases for LLMs"
 readme = {file = "README.md", content-type = "text/markdown" }
 requires-python = ">= 3.8"

--- a/src/server/templates/components/result.jinja
+++ b/src/server/templates/components/result.jinja
@@ -96,9 +96,9 @@
                                  readonly>
                                 <input type="hidden" id="directory-structure-content" value="{{ tree }}" />
                                 {% for line in tree.splitlines() %}
-                                    <div name="tree-line"
+                                    <pre name="tree-line"
                                          class="cursor-pointer hover:line-through hover:text-gray-500"
-                                         onclick="toggleFile(this)">{{ line }}</div>
+                                         onclick="toggleFile(this)">{{ line }}</pre>
                                 {% endfor %}
                             </div>
                         </div>


### PR DESCRIPTION
Fixing this little bug where the directory structure didn't show properly in front-end (digest was still ok)

This was due to the `<div>` container removing extra whitespaces
replaced with a `<pre>` tag to fix it
![image](https://github.com/user-attachments/assets/8c814c3c-bd32-480f-9225-97635d8eea51)


also bumping gitingest to v0.1.4