### PR TITLE
fix subpath cloning

### DIFF
--- a/src/gitingest/cloning.py
+++ b/src/gitingest/cloning.py
@@ -101,7 +101,8 @@ async def clone_repo(config: CloneConfig) -> None:
 
         if partial_clone:
             if config.blob:
-                checkout_cmd += ["sparse-checkout", "set", config.subpath.lstrip("/")[:-1]]
+                # When ingesting from a file url (blob/branch/path/file.txt), we need to remove the file name
+                checkout_cmd += ["sparse-checkout", "set", Path(config.subpath.lstrip("/")).parent]
             else:
                 checkout_cmd += ["sparse-checkout", "set", config.subpath.lstrip("/")]
 


### PR DESCRIPTION
As @filipchristiansen pointed out, the previous code was working by luck because it was not properly removing the filename but only the last character

I guess git checkout was handling the failing filename and falling back to parent directory
![image](https://github.com/user-attachments/assets/ef3b95da-2a52-45c9-8420-36c2702df6a9)

Now fixed with a Path object
 