### PR TITLE
Remove leftover pattern_type usage in IngestionQuery fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,6 @@ def sample_query() -> IngestionQuery:
         max_file_size=1_000_000,
         ignore_patterns={"*.pyc", "__pycache__", ".git"},
         include_patterns=None,
-        pattern_type="exclude",
     )
 
 


### PR DESCRIPTION
The `IngestionQuery` class no longer accepts a parameter named `pattern_type`. This change removes the outdated parameter from the `sample_query` fixture, ensuring consistency with the updated `IngestionQuery` signature and preventing any confusion in tests.
