### PR TITLE
chore: remove unused dependencies and pin fastapi/starlette/uvicorn to fix vulnerabilities

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -95,16 +95,16 @@ repos:
         files: ^src/
         additional_dependencies:
           [
-            chardet,
-            click,
-            fastapi-analytics,
+            click>=8.0.0,
+            "fastapi[standard]>=0.109.1",
+            pydantic,
             pytest-asyncio,
             python-dotenv,
             slowapi,
-            starlette,
+            starlette>=0.40.0,
             tiktoken,
             tomli,
-            uvicorn,
+            uvicorn>=0.11.7,
           ]
       - id: pylint
         name: pylint for tests
@@ -113,17 +113,16 @@ repos:
           - --rcfile=tests/.pylintrc
         additional_dependencies:
           [
-            chardet,
-            click,
-            fastapi-analytics,
-            pytest,
+            click>=8.0.0,
+            "fastapi[standard]>=0.109.1",
+            pydantic,
             pytest-asyncio,
             python-dotenv,
             slowapi,
-            starlette,
-            tomli,
+            starlette>=0.40.0,
             tiktoken,
-            uvicorn,
+            tomli,
+            uvicorn>=0.11.7,
           ]
 
   - repo: meta

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,15 @@ readme = {file = "README.md", content-type = "text/markdown" }
 requires-python = ">= 3.8"
 dependencies = [
     "click>=8.0.0",
+    "fastapi[standard]>=0.109.1",  # Vulnerable to https://osv.dev/vulnerability/PYSEC-2024-38
+    "pydantic",
+    "python-dotenv",
+    "slowapi",
+    "starlette>=0.40.0",  # Vulnerable to https://osv.dev/vulnerability/GHSA-f96h-pmfr-66vw
     "tiktoken",
     "tomli",
     "typing_extensions; python_version < '3.10'",
+    "uvicorn>=0.11.7",  # Vulnerable to https://osv.dev/vulnerability/PYSEC-2020-150
 ]
 
 license = {file = "LICENSE"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-chardet
 click>=8.0.0
 fastapi[standard]>=0.109.1  # Vulnerable to https://osv.dev/vulnerability/PYSEC-2024-38
+pydantic
 python-dotenv
 slowapi
 starlette>=0.40.0  # Vulnerable to https://osv.dev/vulnerability/GHSA-f96h-pmfr-66vw

--- a/src/gitingest/ingestion_schema.py
+++ b/src/gitingest/ingestion_schema.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional, Set
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from gitingest.config import MAX_FILE_SIZE
 
@@ -58,10 +58,7 @@ class IngestionQuery(BaseModel):  # pylint: disable=too-many-instance-attributes
     ignore_patterns: Optional[Set[str]] = None
     include_patterns: Optional[Set[str]] = None
 
-    class Config:
-        """Pydantic model configuration."""
-
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def extract_clone_config(self) -> CloneConfig:
         """


### PR DESCRIPTION
This PR removes dependencies that are no longer needed (`chardet`, `fastapi-analytics`) and updates various Python packages to versions that address known security vulnerabilities. Specifically, `fastapi`, `starlette`, and `uvicorn` have been pinned to ensure patches for identified issues are applied. The changes also include a small tweak to the ingestion schema to align with the latest `pydantic` configuration pattern.

**What Changed?**
- Removed references to `chardet` and `fastapi-analytics` in `.pre-commit-config.yaml` and `requirements.txt`.
- Pinned `fastapi[standard]`, `starlette`, and `uvicorn` to versions fixing their respective security issues.
- Added `pydantic` explicitly to `requirements.txt` and `pyproject.toml`.
- Updated `IngestionQuery` model to use the new `model_config` property from `pydantic`.