### PR TITLE
feat/manual-max-file-size-input: Add option to manually input max file size

### DIFF
--- a/src/server/query_processor.py
+++ b/src/server/query_processor.py
@@ -78,7 +78,7 @@ async def process_query(
         "pattern_type": pattern_type,
         "pattern": pattern,
         "use_manual_input": "true" if is_file_size_manual else "false",
-        "max_file_size_manual": str(slider_position) if is_file_size_manual else "",
+        "max_file_size_manual": slider_position if is_file_size_manual else None,
         "size_unit": size_unit,
     }
 

--- a/src/server/query_processor.py
+++ b/src/server/query_processor.py
@@ -20,6 +20,7 @@ async def process_query(
     pattern: str = "",
     is_index: bool = False,
     is_file_size_manual: bool = False,
+    size_unit: str = "kb",
 ) -> _TemplateResponse:
     """
     Process a query by parsing input, cloning a repository, and generating a summary.
@@ -43,6 +44,8 @@ async def process_query(
         Flag indicating whether the request is for the index page (default is False).
     is_file_size_manual: bool
         Flag indicating if the file size provided is via the manual input (default to False).
+    size_unit: str
+        The unit for the manual file size input ('kb' or 'mb'), by default 'kb'.
 
     Returns
     -------
@@ -74,6 +77,9 @@ async def process_query(
         "default_file_size": slider_position,
         "pattern_type": pattern_type,
         "pattern": pattern,
+        "use_manual_input": "true" if is_file_size_manual else "false",
+        "max_file_size_manual": str(slider_position) if is_file_size_manual else "",
+        "size_unit": size_unit,
     }
 
     try:

--- a/src/server/query_processor.py
+++ b/src/server/query_processor.py
@@ -1,4 +1,4 @@
-""" Process a query by parsing input, cloning a repository, and generating a summary. """
+"""Process a query by parsing input, cloning a repository, and generating a summary."""
 
 from functools import partial
 
@@ -19,6 +19,7 @@ async def process_query(
     pattern_type: str = "exclude",
     pattern: str = "",
     is_index: bool = False,
+    is_file_size_manual: bool = False,
 ) -> _TemplateResponse:
     """
     Process a query by parsing input, cloning a repository, and generating a summary.
@@ -40,6 +41,8 @@ async def process_query(
         Pattern to include or exclude in the query, depending on the pattern type.
     is_index : bool
         Flag indicating whether the request is for the index page (default is False).
+    is_file_size_manual: bool
+        Flag indicating if the file size provided is via the manual input (default to False).
 
     Returns
     -------
@@ -62,7 +65,7 @@ async def process_query(
 
     template = "index.jinja" if is_index else "git.jinja"
     template_response = partial(templates.TemplateResponse, name=template)
-    max_file_size = log_slider_to_size(slider_position)
+    max_file_size = slider_position if is_file_size_manual else log_slider_to_size(slider_position)
 
     context = {
         "request": request,

--- a/src/server/routers/index.py
+++ b/src/server/routers/index.py
@@ -49,6 +49,7 @@ async def index_post(
     max_file_size: int = Form(...),
     max_file_size_manual: Optional[str] = Form(None),
     use_manual_input: bool = Form(...),
+    size_unit: str = Form("kb"),
     pattern_type: str = Form(...),
     pattern: str = Form(...),
 ) -> HTMLResponse:
@@ -67,14 +68,16 @@ async def index_post(
         The input text provided by the user for processing, by default taken from the form.
     max_file_size : int
         The maximum allowed file size for the input, specified by the user.
+    max_file_size_manual : Optional[str], optional
+        The manually entered file size, by default None.
+    use_manual_input : bool
+        Whether to use the manual input instead of the slider, by default False.
+    size_unit : str
+        The unit for the manual file size input ('kb' or 'mb'), by default 'kb'.
     pattern_type : str
         The type of pattern used for the query, specified by the user.
     pattern : str
         The pattern string used in the query, specified by the user.
-    use_manual_input : bool
-        Whether to use the manual input instead of the slider, by default False.
-    max_file_size_manual : Optional[str], optional
-        The manually entered file size in KB, by default None.
 
     Returns
     -------
@@ -83,10 +86,14 @@ async def index_post(
         which will be rendered and returned to the user.
     """
     # Determine the file size based on the input method
-    max_file_size = int(max_file_size_manual) * 1024 if use_manual_input else max_file_size
-    # Print debug information
-    print(f"Received value: {max_file_size_manual}")
-    print(f"Manual: {use_manual_input}")
+    if use_manual_input and max_file_size_manual:
+        # Convert the manual input to bytes based on the size unit
+        size_value = int(max_file_size_manual)
+        if size_unit.lower() == "mb":
+            max_file_size = size_value * 1024 * 1024  # Convert MB to bytes
+        else:  # Default to KB
+            max_file_size = size_value * 1024  # Convert KB to bytes
+
     return await process_query(
         request,
         input_text,
@@ -95,4 +102,5 @@ async def index_post(
         pattern,
         is_index=True,
         is_file_size_manual=use_manual_input,
+        size_unit=size_unit,
     )

--- a/src/server/routers/index.py
+++ b/src/server/routers/index.py
@@ -37,6 +37,9 @@ async def home(request: Request) -> HTMLResponse:
             "request": request,
             "examples": EXAMPLE_REPOS,
             "default_file_size": 243,
+            "default_file_size_manual": 50,
+            "use_manual_input": "false",
+            "size_unit": "kb",
         },
     )
 

--- a/src/server/routers/index.py
+++ b/src/server/routers/index.py
@@ -1,4 +1,6 @@
-""" This module defines the FastAPI router for the home page of the application. """
+"""This module defines the FastAPI router for the home page of the application."""
+
+from typing import Optional
 
 from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse
@@ -45,6 +47,8 @@ async def index_post(
     request: Request,
     input_text: str = Form(...),
     max_file_size: int = Form(...),
+    max_file_size_manual: Optional[str] = Form(None),
+    use_manual_input: bool = Form(...),
     pattern_type: str = Form(...),
     pattern: str = Form(...),
 ) -> HTMLResponse:
@@ -67,6 +71,10 @@ async def index_post(
         The type of pattern used for the query, specified by the user.
     pattern : str
         The pattern string used in the query, specified by the user.
+    use_manual_input : bool
+        Whether to use the manual input instead of the slider, by default False.
+    max_file_size_manual : Optional[str], optional
+        The manually entered file size in KB, by default None.
 
     Returns
     -------
@@ -74,6 +82,11 @@ async def index_post(
         An HTML response containing the results of processing the form input and query logic,
         which will be rendered and returned to the user.
     """
+    # Determine the file size based on the input method
+    max_file_size = int(max_file_size_manual) * 1024 if use_manual_input else max_file_size
+    # Print debug information
+    print(f"Received value: {max_file_size_manual}")
+    print(f"Manual: {use_manual_input}")
     return await process_query(
         request,
         input_text,
@@ -81,4 +94,5 @@ async def index_post(
         pattern_type,
         pattern,
         is_index=True,
+        is_file_size_manual=use_manual_input,
     )

--- a/src/server/templates/components/git_form.jinja
+++ b/src/server/templates/components/git_form.jinja
@@ -2,10 +2,24 @@
     document.addEventListener('DOMContentLoaded', function() {
         const checkbox = document.getElementById('use_manual_input');
         const hiddenInput = document.getElementById('file_size_manual');
+        const sizeUnitInput = document.getElementById('size_unit_input');
+
+        if (sizeUnitInput.value === 'mb') {
+            document.getElementById('size-mb').checked = true;
+        } else {
+            document.getElementById('size-kb').checked = true;
+        }
 
         if (hiddenInput.value === "true") {
             checkbox.checked = true;
-            toggleSizeInputType(checkbox);
+        }
+
+        changeFilesizeInputType(checkbox);
+
+        const slider = document.getElementById('file_size');
+        const sizeValueDisplay = document.getElementById('size_value');
+        if (slider && sizeValueDisplay) {
+            updateSliderDisplay(slider.value);
         }
     });
 
@@ -27,13 +41,20 @@
         });
     }
 
-    function toggleSizeInputType(element) {
+    function changeFilesizeInputType(element) {
         const hiddenInput = document.getElementById('file_size_manual');
         const sliderContainer = document.getElementById('slider_container');
         const manualSizeInput = document.getElementById('manual_size_input_container');
         const manualSizeValueInput = document.getElementById('max_file_size_manual_input');
         const hiddenSizeInput = document.getElementById('max_file_size_manual');
-        hiddenSizeInput.value = manualSizeValueInput.value;
+        const sizeUnitInput = document.getElementById('size_unit_input');
+
+        if (sizeUnitInput.value === 'mb') {
+            document.getElementById('size-mb').checked = true;
+        } else {
+            document.getElementById('size-kb').checked = true;
+        }
+
         hiddenInput.value = element.checked ? "true" : "false";
 
         if (element.checked) {
@@ -61,6 +82,40 @@
         hiddenSizeInput.value = element.value || "1024";
         console.log("Manual size updated to: " + hiddenSizeInput.value + "KB");
     }
+
+    function updateSizeUnit(element) {
+        const hiddenSizeUnitInput = document.getElementById('size_unit_input');
+        const hiddenSizeInput = document.getElementById('max_file_size_manual');
+        const manualSizeValueInput = document.getElementById('max_file_size_manual_input');
+        const sizeUnit = element.value;
+        const currentValue = parseInt(manualSizeValueInput.value);
+
+        // Update the hidden size unit input
+        hiddenSizeUnitInput.value = sizeUnit;
+
+        // Update the max attribute of the manual size input
+        const maxValue = sizeUnit === 'kb' ? 100 * 1024 : 100;
+        manualSizeValueInput.max = maxValue;
+
+        // If switching to MB and current value is over 100, set it to 100
+        if (sizeUnit === 'mb' && currentValue > 100) {
+            manualSizeValueInput.value = 100;
+            // Also update the hidden input
+            hiddenSizeInput.value = 100;
+        }
+
+        console.log("Size unit changed to: " + sizeUnit.toUpperCase());
+    }
+
+    // Add input validation to prevent values over max
+    document.getElementById('max_file_size_manual_input').addEventListener('input', function() {
+        const maxValue = parseInt(this.max);
+        const currentValue = parseInt(this.value);
+
+        if (currentValue > maxValue) {
+            this.value = maxValue;
+        }
+    });
 </script>
 <div class="relative">
     <div class="w-full h-full absolute inset-0 bg-gray-900 rounded-xl translate-y-2 translate-x-2"></div>
@@ -90,11 +145,15 @@
             <input type="hidden"
                    id="file_size_manual"
                    name="use_manual_input"
-                   value="{{ use_manual_input }}">
+                   value="{{ use_manual_input|default('false') }}">
             <input type="hidden"
                    id="max_file_size_manual"
                    name="max_file_size_manual"
                    value="{{ max_file_size_manual }}">
+            <input type="hidden"
+                   id="size_unit_input"
+                   name="size_unit"
+                   value="{{ size_unit|default('kb') }}">
             <input type="hidden" name="pattern_type" value="exclude">
             <input type="hidden" name="pattern" value="">
         </form>
@@ -138,7 +197,12 @@
             <div class="flex items-center gap-4 h-[50px]">
                 <div class="mt-4">
                     <label class="flex flex-col items-center cursor-pointer">
-                        <input type="checkbox" id="use_manual_input" name="use_manual_input" value="false" checked={false} class="sr-only peer w-12" onchange="toggleSizeInputType(this)">
+                        <input type="checkbox"
+                               id="use_manual_input"
+                               name="use_manual_input"
+                               value="false"
+                               class="sr-only peer w-12"
+                               onchange="changeFilesizeInputType(this)">
                         <div class="relative w-12 h-6 bg-[#ebdbb7] peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-[#FE4A60]/30 rounded-full peer border-[2px] border-gray-900 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-5 after:transition-all peer-checked:bg-[#FE4A60]">
                         </div>
                         <p class="ms-1 text-sm font-medium text-gray-900">Manual</p>
@@ -157,18 +221,43 @@
                            value="{{ default_file_size }}"
                            class="w-full h-3 bg-[#FAFAFA] bg-no-repeat bg-[length:50%_100%] bg-[#ebdbb7] appearance-none border-[3px] border-gray-900 rounded-sm focus:outline-none bg-gradient-to-r from-[#FE4A60] to-[#FE4A60] [&::-webkit-slider-thumb]:w-5 [&::-webkit-slider-thumb]:h-7 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:rounded-sm [&::-webkit-slider-thumb]:cursor-pointer [&::-webkit-slider-thumb]:border-solid [&::-webkit-slider-thumb]:border-[3px] [&::-webkit-slider-thumb]:border-gray-900 [&::-webkit-slider-thumb]:shadow-[3px_3px_0_#000]">
                 </div>
-                <div id="manual_size_input_container" class="hidden mt-3">
-                    <label for="max_file_size_manual_input" class="block text-gray-700 mb-1">Manual size (kb):</label>
-                    <input type="number"
-                           id="max_file_size_manual_input"
-                           name="max_file_size_manual"
-                           min="1"
-                           max="102400"
-                           value="1024"
-                           class="lg:w-[150px] sm:w-[100px] border-[3px] border-gray-900 rounded-sm focus:outline-none bg-[#ebdbb7] appearance-none indent-2"
-                           style="-webkit-appearance: none;
-                                  color: #333"
-                           onchange="updateManualSizeValue(this)">
+                <div id="manual_size_input_container" class="hidden mt-3 flex gap-2">
+                    <div>
+                        <label for="max_file_size_manual_input" class="block text-gray-700 mb-1">Include files under:</label>
+                        <input type="number"
+                               id="max_file_size_manual_input"
+                               name="max_file_size_manual"
+                               min="1"
+                               max="{{ '102400' if size_unit == 'kb' else '100' }}"
+                               value="{{ max_file_size_manual }}"
+                               class="lg:w-[150px] sm:w-[100px] border-[3px] border-gray-900 rounded-sm focus:outline-none bg-[#ebdbb7] appearance-none indent-2"
+                               style="-webkit-appearance: none;
+                                      color: #333"
+                               onchange="updateManualSizeValue(this)">
+                    </div>
+                    <div class="flex flex-col justify-end mb-1">
+                        <div class="flex items-center">
+                            <input id="size-kb"
+                                   type="radio"
+                                   value="kb"
+                                   name="size_unit"
+                                   class="w-4 h-4"
+                                   {% if size_unit == 'kb' %}checked{% endif %}
+                                   onchange="updateSizeUnit(this)"
+                                   style="background-color:red">
+                            <label for="size-kb" class="ms-2 text-sm font-medium text-gray-900">KB</label>
+                        </div>
+                        <div class="flex items-center mt-1">
+                            <input id="size-mb"
+                                   type="radio"
+                                   value="mb"
+                                   name="size_unit"
+                                   class="w-4 h-4 text-[#FE4A60] bg-[#FE4A60] border-[#FE4A60] focus:ring-[#FE4A60]"
+                                   {% if size_unit == 'mb' %}checked{% endif %}
+                                   onchange="updateSizeUnit(this)">
+                            <label for="size-mb" class="ms-2 text-sm font-medium text-gray-900">MB</label>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
@@ -187,4 +276,3 @@
             </div>
         {% endif %}
     </div>
-</div>

--- a/src/server/templates/components/git_form.jinja
+++ b/src/server/templates/components/git_form.jinja
@@ -15,12 +15,6 @@
         }
 
         changeFilesizeInputType(checkbox);
-
-        const slider = document.getElementById('file_size');
-        const sizeValueDisplay = document.getElementById('size_value');
-        if (slider && sizeValueDisplay) {
-            updateSliderDisplay(slider.value);
-        }
     });
 
     function changePattern(element) {
@@ -48,17 +42,11 @@
         const hiddenSizeInput = document.getElementById('max_file_size_manual');
         const sizeUnitInput = document.getElementById('size_unit_input');
 
-        if (sizeUnitInput.value === 'mb') {
-            document.getElementById('size-mb').checked = true;
-        } else {
-            document.getElementById('size-kb').checked = true;
-        }
-
         hiddenInput.value = element.checked ? "true" : "false";
 
         if (element.checked) {
-            sliderContainer.classList.add('hidden');
-            manualSizeInput.classList.remove('hidden');
+            sliderContainer.style.display = "none";
+            manualSizeInput.style.display = "flex";
             const sizeUnit = sizeUnitInput.value;
             const maxValue = sizeUnit === 'kb' ? 100 * 1024 : 100;
             manualSizeValueInput.max = maxValue;
@@ -67,8 +55,9 @@
             }
             hiddenSizeInput.value = manualSizeValueInput.value || "1024";
         } else {
-            sliderContainer.classList.remove('hidden');
-            manualSizeInput.classList.add('hidden');
+            manualSizeInput.style.display = "none";
+            sliderContainer.style.display = "flex";
+            sliderContainer.style.flexDirection = "column";
 
             const sliderValue = document.getElementById('file_size').value;
             hiddenSizeInput.value = sliderValue;
@@ -96,21 +85,10 @@
             manualSizeValueInput.value = 100;
             hiddenSizeInput.value = 100;
         }
-
-        console.log("Size unit changed to: " + sizeUnit.toUpperCase());
     }
-
-    document.getElementById('max_file_size_manual_input').addEventListener('input', function() {
-        const maxValue = parseInt(this.max);
-        const currentValue = parseInt(this.value);
-
-        if (currentValue > maxValue) {
-            this.value = maxValue;
-        }
-    });
 </script>
 <div class="relative">
-    <div class="w-full h-full absolute inset-0 bg-gray-900 rounded-xl translate-y-2 translate-x-2"></div>
+    <div class="w-full lg:h-[90%] sm:h-full absolute inset-0 bg-gray-900 rounded-xl translate-y-2 translate-x-2"></div>
     <div class="rounded-xl relative z-20 pl-8 sm:pl-10 pr-8 sm:pr-16 py-8 border-[3px] border-gray-900 bg-[#fff4da]">
         <img src="https://cdn.devdojo.com/images/january2023/shape-1.png"
              class="absolute md:block hidden left-0 h-[4.5rem] w-[4.5rem] bottom-0 -translate-x-full ml-3">
@@ -186,18 +164,17 @@
                     </div>
                 </div>
             </div>
-            <div class="flex items-center gap-4 h-[50px]">
+            <div class="flex items-center gap-4 h-[40px]">
                 <div class="mt-4">
                     <label class="flex flex-col items-center cursor-pointer">
                         <input type="checkbox"
                                id="use_manual_input"
                                name="use_manual_input"
-                               value="false"
                                class="sr-only peer w-12"
                                onchange="changeFilesizeInputType(this)">
                         <div class="relative w-12 h-6 bg-[#ebdbb7] peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-[#FE4A60]/30 rounded-full peer border-[2px] border-gray-900 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-5 after:transition-all peer-checked:bg-[#FE4A60]">
                         </div>
-                        <p class="ms-1 text-sm font-medium text-gray-900">Manual</p>
+                        <p class="ms-1 text-xs font-medium text-gray-900">Manual</p>
                     </label>
                 </div>
                 <div id="slider_container" class="w-[200px] sm:w-[200px] mt-3">
@@ -213,7 +190,7 @@
                            value="{{ default_file_size }}"
                            class="w-full h-3 bg-[#FAFAFA] bg-no-repeat bg-[length:50%_100%] bg-[#ebdbb7] appearance-none border-[3px] border-gray-900 rounded-sm focus:outline-none bg-gradient-to-r from-[#FE4A60] to-[#FE4A60] [&::-webkit-slider-thumb]:w-5 [&::-webkit-slider-thumb]:h-7 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:rounded-sm [&::-webkit-slider-thumb]:cursor-pointer [&::-webkit-slider-thumb]:border-solid [&::-webkit-slider-thumb]:border-[3px] [&::-webkit-slider-thumb]:border-gray-900 [&::-webkit-slider-thumb]:shadow-[3px_3px_0_#000]">
                 </div>
-                <div id="manual_size_input_container" class="hidden mt-3 flex gap-2">
+                <div id="manual_size_input_container" class="mt-3 flex gap-2">
                     <div>
                         <label for="max_file_size_manual_input" class="block text-gray-700 mb-1">Include files under:</label>
                         <input type="number"
@@ -221,7 +198,7 @@
                                name="max_file_size_manual"
                                min="1"
                                max="{{ '102400' if size_unit == 'kb' else '100' }}"
-                               value="{{ max_file_size_manual }}"
+                               value="{{ default_file_size_manual }}"
                                class="lg:w-[150px] sm:w-[100px] border-[3px] border-gray-900 rounded-sm focus:outline-none bg-[#ebdbb7] appearance-none indent-2"
                                style="-webkit-appearance: none;
                                       color: #333"
@@ -235,8 +212,7 @@
                                    name="size_unit"
                                    class="w-4 h-4"
                                    {% if size_unit == 'kb' %}checked{% endif %}
-                                   onchange="updateSizeUnit(this)"
-                                   style="background-color:red">
+                                   onchange="updateSizeUnit(this)">
                             <label for="size-kb" class="ms-2 text-sm font-medium text-gray-900">KB</label>
                         </div>
                         <div class="flex items-center mt-1">

--- a/src/server/templates/components/git_form.jinja
+++ b/src/server/templates/components/git_form.jinja
@@ -1,4 +1,14 @@
 <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const checkbox = document.getElementById('use_manual_input');
+        const hiddenInput = document.getElementById('file_size_manual');
+
+        if (hiddenInput.value === "true") {
+            checkbox.checked = true;
+            toggleSizeInputType(checkbox);
+        }
+    });
+
     function changePattern(element) {
         console.log("Pattern changed", element.value);
         let patternType = element.value;
@@ -8,7 +18,6 @@
             if (element.textContent.includes("Directory structure:")) {
                 return;
             }
-
             element.classList.toggle('line-through');
             element.classList.toggle('text-gray-500');
             element.classList.toggle('hover:text-inherit');
@@ -16,6 +25,41 @@
             element.classList.toggle('hover:line-through');
             element.classList.toggle('hover:text-gray-500');
         });
+    }
+
+    function toggleSizeInputType(element) {
+        const hiddenInput = document.getElementById('file_size_manual');
+        const sliderContainer = document.getElementById('slider_container');
+        const manualSizeInput = document.getElementById('manual_size_input_container');
+        const manualSizeValueInput = document.getElementById('max_file_size_manual_input');
+        const hiddenSizeInput = document.getElementById('max_file_size_manual');
+        hiddenSizeInput.value = manualSizeValueInput.value;
+        hiddenInput.value = element.checked ? "true" : "false";
+
+        if (element.checked) {
+            sliderContainer.classList.add('hidden');
+            manualSizeInput.classList.remove('hidden');
+
+            if (!manualSizeValueInput.value || manualSizeValueInput.value.trim() === '') {
+                manualSizeValueInput.value = "1024";
+            }
+            hiddenSizeInput.value = manualSizeValueInput.value || "1024";
+        } else {
+            sliderContainer.classList.remove('hidden');
+            manualSizeInput.classList.add('hidden');
+
+            const sliderValue = document.getElementById('file_size').value;
+            hiddenSizeInput.value = sliderValue;
+        }
+
+        console.log("Use manual input: " + hiddenInput.value);
+        console.log("Manual size value: " + hiddenSizeInput.value);
+    }
+
+    function updateManualSizeValue(element) {
+        const hiddenSizeInput = document.getElementById('max_file_size_manual');
+        hiddenSizeInput.value = element.value || "1024";
+        console.log("Manual size updated to: " + hiddenSizeInput.value + "KB");
     }
 </script>
 <div class="relative">
@@ -43,10 +87,18 @@
                     Ingest
                 </button>
             </div>
+            <input type="hidden"
+                   id="file_size_manual"
+                   name="use_manual_input"
+                   value="{{ use_manual_input }}">
+            <input type="hidden"
+                   id="max_file_size_manual"
+                   name="max_file_size_manual"
+                   value="{{ max_file_size_manual }}">
             <input type="hidden" name="pattern_type" value="exclude">
             <input type="hidden" name="pattern" value="">
         </form>
-        <div class="mt-4 relative z-20 flex flex-wrap gap-4 items-start">
+        <div class="mt-4 relative z-20 flex flex-wrap gap-4 items-center">
             <!-- Pattern selector -->
             <div class="w-[200px] sm:w-[250px] mr-9 mt-4">
                 <div class="relative">
@@ -83,18 +135,41 @@
                     </div>
                 </div>
             </div>
-            <div class="w-[200px] sm:w-[200px] mt-3">
-                <label for="file_size" class="block text-gray-700 mb-1">
-                    Include files under: <span id="size_value" class="font-bold">50kb</span>
-                </label>
-                <input type="range"
-                       id="file_size"
-                       name="max_file_size"
-                       min="0"
-                       max="500"
-                       required
-                       value="{{ default_file_size }}"
-                       class="w-full h-3 bg-[#FAFAFA] bg-no-repeat bg-[length:50%_100%] bg-[#ebdbb7] appearance-none border-[3px] border-gray-900 rounded-sm focus:outline-none bg-gradient-to-r from-[#FE4A60] to-[#FE4A60] [&::-webkit-slider-thumb]:w-5 [&::-webkit-slider-thumb]:h-7 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:rounded-sm [&::-webkit-slider-thumb]:cursor-pointer [&::-webkit-slider-thumb]:border-solid [&::-webkit-slider-thumb]:border-[3px] [&::-webkit-slider-thumb]:border-gray-900 [&::-webkit-slider-thumb]:shadow-[3px_3px_0_#000]  ">
+            <div class="flex items-center gap-4 h-[50px]">
+                <div class="mt-4">
+                    <label class="flex flex-col items-center cursor-pointer">
+                        <input type="checkbox" id="use_manual_input" name="use_manual_input" value="false" checked={false} class="sr-only peer w-12" onchange="toggleSizeInputType(this)">
+                        <div class="relative w-12 h-6 bg-[#ebdbb7] peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-[#FE4A60]/30 rounded-full peer border-[2px] border-gray-900 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-5 after:transition-all peer-checked:bg-[#FE4A60]">
+                        </div>
+                        <p class="ms-1 text-sm font-medium text-gray-900">Manual</p>
+                    </label>
+                </div>
+                <div id="slider_container" class="w-[200px] sm:w-[200px] mt-3">
+                    <label for="file_size" class="block text-gray-700 mb-1">
+                        Include files under: <span id="size_value" class="font-bold">50kb</span>
+                    </label>
+                    <input type="range"
+                           id="file_size"
+                           name="max_file_size"
+                           min="0"
+                           max="500"
+                           required
+                           value="{{ default_file_size }}"
+                           class="w-full h-3 bg-[#FAFAFA] bg-no-repeat bg-[length:50%_100%] bg-[#ebdbb7] appearance-none border-[3px] border-gray-900 rounded-sm focus:outline-none bg-gradient-to-r from-[#FE4A60] to-[#FE4A60] [&::-webkit-slider-thumb]:w-5 [&::-webkit-slider-thumb]:h-7 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:rounded-sm [&::-webkit-slider-thumb]:cursor-pointer [&::-webkit-slider-thumb]:border-solid [&::-webkit-slider-thumb]:border-[3px] [&::-webkit-slider-thumb]:border-gray-900 [&::-webkit-slider-thumb]:shadow-[3px_3px_0_#000]">
+                </div>
+                <div id="manual_size_input_container" class="hidden mt-3">
+                    <label for="max_file_size_manual_input" class="block text-gray-700 mb-1">Manual size (kb):</label>
+                    <input type="number"
+                           id="max_file_size_manual_input"
+                           name="max_file_size_manual"
+                           min="1"
+                           max="102400"
+                           value="1024"
+                           class="lg:w-[150px] sm:w-[100px] border-[3px] border-gray-900 rounded-sm focus:outline-none bg-[#ebdbb7] appearance-none indent-2"
+                           style="-webkit-appearance: none;
+                                  color: #333"
+                           onchange="updateManualSizeValue(this)">
+                </div>
             </div>
         </div>
         {% if show_examples %}

--- a/src/server/templates/components/git_form.jinja
+++ b/src/server/templates/components/git_form.jinja
@@ -24,7 +24,6 @@
     });
 
     function changePattern(element) {
-        console.log("Pattern changed", element.value);
         let patternType = element.value;
         const files = document.getElementsByName("tree-line");
 
@@ -60,9 +59,11 @@
         if (element.checked) {
             sliderContainer.classList.add('hidden');
             manualSizeInput.classList.remove('hidden');
-
-            if (!manualSizeValueInput.value || manualSizeValueInput.value.trim() === '') {
-                manualSizeValueInput.value = "1024";
+            const sizeUnit = sizeUnitInput.value;
+            const maxValue = sizeUnit === 'kb' ? 100 * 1024 : 100;
+            manualSizeValueInput.max = maxValue;
+            if (parseInt(manualSizeValueInput.value) > maxValue) {
+                manualSizeValueInput.value = maxValue;
             }
             hiddenSizeInput.value = manualSizeValueInput.value || "1024";
         } else {
@@ -72,15 +73,11 @@
             const sliderValue = document.getElementById('file_size').value;
             hiddenSizeInput.value = sliderValue;
         }
-
-        console.log("Use manual input: " + hiddenInput.value);
-        console.log("Manual size value: " + hiddenSizeInput.value);
     }
 
     function updateManualSizeValue(element) {
         const hiddenSizeInput = document.getElementById('max_file_size_manual');
         hiddenSizeInput.value = element.value || "1024";
-        console.log("Manual size updated to: " + hiddenSizeInput.value + "KB");
     }
 
     function updateSizeUnit(element) {
@@ -90,24 +87,19 @@
         const sizeUnit = element.value;
         const currentValue = parseInt(manualSizeValueInput.value);
 
-        // Update the hidden size unit input
         hiddenSizeUnitInput.value = sizeUnit;
 
-        // Update the max attribute of the manual size input
         const maxValue = sizeUnit === 'kb' ? 100 * 1024 : 100;
         manualSizeValueInput.max = maxValue;
 
-        // If switching to MB and current value is over 100, set it to 100
         if (sizeUnit === 'mb' && currentValue > 100) {
             manualSizeValueInput.value = 100;
-            // Also update the hidden input
             hiddenSizeInput.value = 100;
         }
 
         console.log("Size unit changed to: " + sizeUnit.toUpperCase());
     }
 
-    // Add input validation to prevent values over max
     document.getElementById('max_file_size_manual_input').addEventListener('input', function() {
         const maxValue = parseInt(this.max);
         const currentValue = parseInt(this.value);

--- a/src/static/js/utils.js
+++ b/src/static/js/utils.js
@@ -69,6 +69,11 @@ function handleSubmit(event, showLoading = false) {
         formData.append('pattern', pattern.value);
     }
 
+    // Save the current state of the form for restoration after response
+    const useManualInput = document.getElementById('use_manual_input').checked;
+    const sizeUnit = document.getElementById('size_unit_input').value;
+    const manualSizeValue = document.getElementById('max_file_size_manual_input')?.value || '';
+
     const originalContent = submitButton.innerHTML;
     const currentStars = document.getElementById('github-stars')?.textContent;
 
@@ -104,6 +109,9 @@ function handleSubmit(event, showLoading = false) {
                 // Reinitialize slider functionality
                 initializeSlider();
 
+                // Restore form state
+                restoreFormState(useManualInput, sizeUnit, manualSizeValue);
+
                 const starsElement = document.getElementById('github-stars');
                 if (starsElement && starCount) {
                     starsElement.textContent = starCount;
@@ -120,6 +128,47 @@ function handleSubmit(event, showLoading = false) {
             submitButton.disabled = false;
             submitButton.innerHTML = originalContent;
         });
+}
+
+// Function to restore form state after receiving response
+function restoreFormState(useManualInput, sizeUnit, manualSizeValue) {
+    const checkbox = document.getElementById('use_manual_input');
+    const sizeUnitInput = document.getElementById('size_unit_input');
+    const manualSizeValueInput = document.getElementById('max_file_size_manual_input');
+    const hiddenInput = document.getElementById('file_size_manual');
+    const sliderContainer = document.getElementById('slider_container');
+    const manualSizeInput = document.getElementById('manual_size_input_container');
+
+    if (!checkbox || !sizeUnitInput) return;
+
+    // Set checkbox state
+    checkbox.checked = useManualInput;
+    hiddenInput.value = useManualInput ? "true" : "false";
+
+    // Set size unit
+    sizeUnitInput.value = sizeUnit;
+    if (sizeUnit === 'mb') {
+        document.getElementById('size-mb').checked = true;
+    } else {
+        document.getElementById('size-kb').checked = true;
+    }
+
+    // Set manual size value if applicable
+    if (manualSizeValueInput && manualSizeValue) {
+        manualSizeValueInput.value = manualSizeValue;
+    }
+
+    // Show/hide appropriate containers based on checkbox state
+    if (useManualInput) {
+        if (sliderContainer) sliderContainer.style.display = "none";
+        if (manualSizeInput) manualSizeInput.style.display = "flex";
+    } else {
+        if (manualSizeInput) manualSizeInput.style.display = "none";
+        if (sliderContainer) {
+            sliderContainer.style.display = "flex";
+            sliderContainer.style.flexDirection = "column";
+        }
+    }
 }
 
 function copyFullDigest() {
@@ -147,7 +196,6 @@ function copyFullDigest() {
 
 // Add the logSliderToSize helper function
 function logSliderToSize(position) {
-    const minp = 0;
     const maxp = 500;
     const minv = Math.log(1);
     const maxv = Math.log(102400);
@@ -193,6 +241,7 @@ window.copyText = copyText;
 window.handleSubmit = handleSubmit;
 window.initializeSlider = initializeSlider;
 window.formatSize = formatSize;
+window.restoreFormState = restoreFormState;
 
 // Add this new function
 function setupGlobalEnterHandler() {


### PR DESCRIPTION
## Description

Added a toggle to manually input the max file size instead of using the slider.

## Major changes:

- #### Files modified:
  
  - `git_form.jinja`
    
  - `index.py`
    
  - `process_query.py`
    
  - `utils.js`
    
- #### Added three form values / new params in the POST endpoint in `index.py`called:
  
  - `use_manual_input`: bool
    
  - `max_file_size_manual`: int
    
  - `size_unit:`str
    

    These are also added to the context in `process_query.py`

- #### Added three new inputs elements
  
  - `checkbox`: toggle use of slider vs. manual input
    
  - `number`: accepts manual file size in by manually inputing a value of using the increment/decrement triggers
    
  - `radio`: switch between accepted file sizes between`kb` or `mb`
    
- #### Keep new form/input states after receving results and submitting form
  
  - Added a function in `utils.js` called `restoreFormState` to keep current input/form values after a successfull POST request

## Minor changes

- Removed console log in `changePattern`function in `git_form.jinja`
  
- Reduced height of the absolute div (shadow effect) at large screens to 90% (`lg:h-90% sm:h-fulll)`) using media query in Tailwind to compensate to the slight change in dimesion of the div containg the form due to the addition of the new input element
  
- Removed unused variable `minp` in `utils.js`
  
- Added new context values in the home page to pass in default values called `default_file_size_manual`, `use_manual_input` and `size_unit`