### PR TITLE
refactor: rework how symlinks are processed (no longer resolve)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+    "configurations": [
+        {
+            "name": "Python Debugger: Module",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "uvicorn",
+            "args": ["server.main:app", "--host", "0.0.0.0", "--port", "8000"],
+            "cwd": "${workspaceFolder}/src"
+        }
+    ]
+}

--- a/src/gitingest/output_formatters.py
+++ b/src/gitingest/output_formatters.py
@@ -31,7 +31,7 @@ def format_node(node: FileSystemNode, query: IngestionQuery) -> Tuple[str, str, 
 
     if node.type == FileSystemNodeType.DIRECTORY:
         summary += f"Files analyzed: {node.file_count}\n"
-    else:
+    elif node.type == FileSystemNodeType.FILE:
         summary += f"File: {node.name}\n"
         summary += f"Lines: {len(node.content.splitlines()):,}\n"
 
@@ -101,7 +101,7 @@ def _gather_file_contents(node: FileSystemNode) -> str:
     str
         The concatenated content of all files under the given node.
     """
-    if node.type == FileSystemNodeType.FILE:
+    if node.type != FileSystemNodeType.DIRECTORY:
         return node.content_string
 
     # Recursively gather contents of all files under the current directory
@@ -142,6 +142,8 @@ def _create_tree_structure(query: IngestionQuery, node: FileSystemNode, prefix: 
     display_name = node.name
     if node.type == FileSystemNodeType.DIRECTORY:
         display_name += "/"
+    elif node.type == FileSystemNodeType.SYMLINK:
+        display_name += " -> " + node.path.readlink().name
 
     tree_str += f"{prefix}{current_prefix}{display_name}\n"
 

--- a/src/gitingest/schemas/filesystem_schema.py
+++ b/src/gitingest/schemas/filesystem_schema.py
@@ -18,6 +18,7 @@ class FileSystemNodeType(Enum):
 
     DIRECTORY = auto()
     FILE = auto()
+    SYMLINK = auto()
 
 
 @dataclass
@@ -91,7 +92,8 @@ class FileSystemNode:  # pylint: disable=too-many-instance-attributes
         """
         parts = [
             SEPARATOR,
-            f"File: {str(self.path_str).replace(os.sep, '/')}",
+            f"{self.type.name}: {str(self.path_str).replace(os.sep, '/')}"
+            + (f" -> {self.path.readlink().name}" if self.type == FileSystemNodeType.SYMLINK else ""),
             SEPARATOR,
             f"{self.content}",
         ]
@@ -115,6 +117,9 @@ class FileSystemNode:  # pylint: disable=too-many-instance-attributes
         """
         if self.type == FileSystemNodeType.DIRECTORY:
             raise ValueError("Cannot read content of a directory node")
+
+        if self.type == FileSystemNodeType.SYMLINK:
+            return ""
 
         if not is_text_file(self.path):
             return "[Non-text file]"


### PR DESCRIPTION
Some changes to how we handle symlinks. We no longer resolve them, which should reduce the complexity by a nice bit.

We also now show the target name in the output.

I also added a `launch.json` file for debugging because it took me a while to figure out how to get the debugger to work.

Yeah, that's it.

Please test before merging because I'm a bit of a dingus sometimes
