### PR TITLE
"fix": Error: UTF-16 stream does not start with BOM

### DIFF
--- a/src/gitingest/schemas/filesystem_schema.py
+++ b/src/gitingest/schemas/filesystem_schema.py
@@ -137,6 +137,8 @@ class FileSystemNode:  # pylint: disable=too-many-instance-attributes
                     return f.read()
             except UnicodeDecodeError:
                 continue
+            except UnicodeError:
+                continue
             except OSError as exc:
                 return f"Error reading file: {exc}"
 

--- a/src/gitingest/utils/file_utils.py
+++ b/src/gitingest/utils/file_utils.py
@@ -66,6 +66,8 @@ def is_text_file(path: Path) -> bool:
                 return True
         except UnicodeDecodeError:
             continue
+        except UnicodeError:
+            continue
         except OSError:
             return False
 


### PR DESCRIPTION
This PR prevents crash due to #230 #231 

This is a 🤷-style PR because idk if adding more duct tape safeguards to the encoding process is the way to go but I'm opening this so we can discuss at least.