### PR TITLE
feat(web-ui): add private-GitHub ingestion via PAT

### DIFF
--- a/src/gitingest/entrypoint.py
+++ b/src/gitingest/entrypoint.py
@@ -73,6 +73,7 @@ async def ingest_async(
             from_web=False,
             include_patterns=include_patterns,
             ignore_patterns=exclude_patterns,
+            token=token,
         )
 
         if query.url:

--- a/src/gitingest/query_parsing.py
+++ b/src/gitingest/query_parsing.py
@@ -29,6 +29,7 @@ async def parse_query(
     from_web: bool,
     include_patterns: Optional[Union[str, Set[str]]] = None,
     ignore_patterns: Optional[Union[str, Set[str]]] = None,
+    token: Optional[str] = None,
 ) -> IngestionQuery:
     """
     Parse the input source (URL or path) to extract relevant details for the query.
@@ -49,7 +50,10 @@ async def parse_query(
         Patterns to include, by default None. Can be a set of strings or a single string.
     ignore_patterns : Union[str, Set[str]], optional
         Patterns to ignore, by default None. Can be a set of strings or a single string.
-
+    token : str, optional
+        GitHub personal-access token (PAT). Needed when *source* refers to a
+        **private** repository. Can also be set via the ``GITHUB_TOKEN`` env var.
+        Must start with 'github_pat_' or 'gph_' for GitHub repositories.
     Returns
     -------
     IngestionQuery
@@ -59,7 +63,7 @@ async def parse_query(
     # Determine the parsing method based on the source type
     if from_web or urlparse(source).scheme in ("https", "http") or any(h in source for h in KNOWN_GIT_HOSTS):
         # We either have a full URL or a domain-less slug
-        query = await _parse_remote_repo(source)
+        query = await _parse_remote_repo(source, token=token)
     else:
         # Local path scenario
         query = _parse_local_dir_path(source)

--- a/src/server/query_processor.py
+++ b/src/server/query_processor.py
@@ -1,6 +1,7 @@
 """Process a query by parsing input, cloning a repository, and generating a summary."""
 
 from functools import partial
+from typing import Optional
 
 from fastapi import Request
 from starlette.templating import _TemplateResponse
@@ -19,6 +20,7 @@ async def process_query(
     pattern_type: str = "exclude",
     pattern: str = "",
     is_index: bool = False,
+    token: Optional[str] = None,
 ) -> _TemplateResponse:
     """
     Process a query by parsing input, cloning a repository, and generating a summary.
@@ -40,6 +42,9 @@ async def process_query(
         Pattern to include or exclude in the query, depending on the pattern type.
     is_index : bool
         Flag indicating whether the request is for the index page (default is False).
+    token : str, optional
+        GitHub personal-access token (PAT). Needed when *input_text* refers to a
+        **private** repository.
 
     Returns
     -------
@@ -71,6 +76,7 @@ async def process_query(
         "default_file_size": slider_position,
         "pattern_type": pattern_type,
         "pattern": pattern,
+        "token": token,
     }
 
     try:
@@ -80,12 +86,13 @@ async def process_query(
             from_web=True,
             include_patterns=include_patterns,
             ignore_patterns=exclude_patterns,
+            token=token,
         )
         if not query.url:
             raise ValueError("The 'url' parameter is required.")
 
         clone_config = query.extract_clone_config()
-        await clone_repo(clone_config)
+        await clone_repo(clone_config, token=token)
         summary, tree, content = ingest_query(query)
         with open(f"{clone_config.local_path}.txt", "w", encoding="utf-8") as f:
             f.write(tree + "\n" + content)

--- a/src/server/routers/dynamic.py
+++ b/src/server/routers/dynamic.py
@@ -50,6 +50,7 @@ async def process_catch_all(
     max_file_size: int = Form(...),
     pattern_type: str = Form(...),
     pattern: str = Form(...),
+    token: str = Form(...),
 ) -> HTMLResponse:
     """
     Process the form submission with user input for query parameters.
@@ -69,13 +70,16 @@ async def process_catch_all(
         The type of pattern used for the query, specified by the user.
     pattern : str
         The pattern string used in the query, specified by the user.
-
+    token : str
+        GitHub personal-access token (PAT). Needed when *input_text* refers to a
+        **private** repository.
     Returns
     -------
     HTMLResponse
         An HTML response generated after processing the form input and query logic,
         which will be rendered and returned to the user.
     """
+    resolved_token = None if token == "" else token
     return await process_query(
         request,
         input_text,
@@ -83,4 +87,5 @@ async def process_catch_all(
         pattern_type,
         pattern,
         is_index=False,
+        token=resolved_token,
     )

--- a/src/server/routers/index.py
+++ b/src/server/routers/index.py
@@ -47,6 +47,7 @@ async def index_post(
     max_file_size: int = Form(...),
     pattern_type: str = Form(...),
     pattern: str = Form(...),
+    token: str = Form(...),
 ) -> HTMLResponse:
     """
     Process the form submission with user input for query parameters.
@@ -67,13 +68,16 @@ async def index_post(
         The type of pattern used for the query, specified by the user.
     pattern : str
         The pattern string used in the query, specified by the user.
-
+    token : str
+        GitHub personal-access token (PAT). Needed when *input_text* refers to a
+        **private** repository.
     Returns
     -------
     HTMLResponse
         An HTML response containing the results of processing the form input and query logic,
         which will be rendered and returned to the user.
     """
+    resolved_token = None if token == "" else token
     return await process_query(
         request,
         input_text,
@@ -81,4 +85,5 @@ async def index_post(
         pattern_type,
         pattern,
         is_index=True,
+        token=resolved_token,
     )

--- a/src/server/templates/components/git_form.jinja
+++ b/src/server/templates/components/git_form.jinja
@@ -144,6 +144,19 @@
                                        class="py-2 px-2 bg-[#E8F0FE] focus:outline-none w-full rounded">
                             </div>
                         </div>
+                        <!-- Help section -->
+                        <div class="mt-2 flex items-center space-x-1">
+                            <a href="https://github.com/settings/tokens/new?description=gitingest&scopes=repo"
+                               target="_blank"
+                               rel="noopener noreferrer"
+                               class="text-sm text-gray-600 hover:text-gray-800 flex items-center space-x-1 underline">
+                                <span>Get your token</span>
+                                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" 
+                                          d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path>
+                                </svg>
+                            </a>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/server/templates/components/git_form.jinja
+++ b/src/server/templates/components/git_form.jinja
@@ -17,88 +17,139 @@
             element.classList.toggle('hover:text-gray-500');
         });
     }
+
+    function toggleAccessSettings() {
+        const container = document.getElementById('accessSettingsContainer');
+        const checkbox = document.getElementById('showAccessSettings');
+        const row = document.getElementById('controlsRow');
+        const show = checkbox.checked;
+        container.classList.toggle('hidden', !show);
+        row.classList.toggle('mb-8', show);
+    }
 </script>
 <div class="relative">
     <div class="w-full h-full absolute inset-0 bg-gray-900 rounded-xl translate-y-2 translate-x-2"></div>
     <div class="rounded-xl relative z-20 pl-8 sm:pl-10 pr-8 sm:pr-16 py-8 border-[3px] border-gray-900 bg-[#fff4da]">
         <img src="https://cdn.devdojo.com/images/january2023/shape-1.png"
              class="absolute md:block hidden left-0 h-[4.5rem] w-[4.5rem] bottom-0 -translate-x-full ml-3">
-        <form class="flex md:flex-row flex-col w-full h-full justify-center items-stretch space-y-5 md:space-y-0 md:space-x-5"
-              id="ingestForm"
+        <!-- Ingest Form -->
+        <form id="ingestForm"
+              method="post"
               onsubmit="handleSubmit(event{% if is_index %}, true{% endif %})">
-            <div class="relative w-full h-full">
-                <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0 z-10"></div>
-                <input type="text"
-                       name="input_text"
-                       id="input_text"
-                       placeholder="https://github.com/..."
-                       value="{{ repo_url if repo_url else '' }}"
-                       required
-                       class="border-[3px] w-full relative z-20 border-gray-900 placeholder-gray-600 text-lg font-medium focus:outline-none py-3.5 px-6 rounded">
+            <!-- Top row: repo URL + Ingest button -->
+            <div class="flex md:flex-row flex-col w-full h-full justify-center items-stretch space-y-5 md:space-y-0 md:space-x-5">
+                <!-- Repository URL Input -->
+                <div class="relative w-full h-full">
+                    <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0 z-10"></div>
+                    <input type="text"
+                           name="input_text"
+                           id="input_text"
+                           placeholder="https://github.com/..."
+                           value="{{ repo_url if repo_url else '' }}"
+                           required
+                           class="border-[3px] w-full relative z-20 border-gray-900 placeholder-gray-600 text-lg font-medium focus:outline-none py-3.5 px-6 rounded">
+                </div>
+                <!-- Ingest button -->
+                <div class="relative w-auto flex-shrink-0 h-full group">
+                    <div class="w-full h-full rounded bg-gray-800 translate-y-1 translate-x-1 absolute inset-0 z-10"></div>
+                    <button type="submit"
+                            class="py-3.5 rounded px-6 group-hover:-translate-y-px group-hover:-translate-x-px ease-out duration-300 z-20 relative w-full border-[3px] border-gray-900 font-medium bg-[#ffc480] tracking-wide text-lg flex-shrink-0 text-gray-900">
+                        Ingest
+                    </button>
+                </div>
             </div>
-            <div class="relative w-auto flex-shrink-0 h-full group">
-                <div class="w-full h-full rounded bg-gray-800 translate-y-1 translate-x-1 absolute inset-0 z-10"></div>
-                <button type="submit"
-                        class="py-3.5 rounded px-6 group-hover:-translate-y-px group-hover:-translate-x-px ease-out duration-300 z-20 relative w-full border-[3px] border-gray-900 font-medium bg-[#ffc480] tracking-wide text-lg flex-shrink-0 text-gray-900">
-                    Ingest
-                </button>
-            </div>
+            <!-- Hidden fields -->
             <input type="hidden" name="pattern_type" value="exclude">
             <input type="hidden" name="pattern" value="">
-        </form>
-        <div class="mt-4 relative z-20 flex flex-wrap gap-4 items-start">
-            <!-- Pattern selector -->
-            <div class="w-[200px] sm:w-[250px] mr-9 mt-4">
-                <div class="relative">
-                    <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0 z-10"></div>
-                    <div class="flex relative z-20 border-[3px] border-gray-900 rounded bg-white">
-                        <div class="relative flex items-center">
-                            <select id="pattern_type"
-                                    onchange="changePattern(this)"
-                                    name="pattern_type"
-                                    class="w-21 py-2 pl-2 pr-6 appearance-none bg-[#e6e8eb] focus:outline-none border-r-[3px] border-gray-900">
-                                <option value="exclude"
-                                        {% if pattern_type == 'exclude' or not pattern_type %}selected{% endif %}>
-                                    Exclude
-                                </option>
-                                <option value="include" {% if pattern_type == 'include' %}selected{% endif %}>Include</option>
-                            </select>
-                            <svg class="absolute right-2 w-4 h-4 pointer-events-none"
-                                 xmlns="http://www.w3.org/2000/svg"
-                                 viewBox="0 0 24 24"
-                                 fill="none"
-                                 stroke="currentColor"
-                                 stroke-width="2"
-                                 stroke-linecap="round"
-                                 stroke-linejoin="round">
-                                <polyline points="6 9 12 15 18 9" />
-                            </svg>
+            <!-- Controls row: pattern selector, file size slider, PAT checkbox with PAT field below -->
+            <div id="controlsRow"
+                 class="mt-7 flex flex-col md:flex-row items-start md:items-center gap-6 md:gap-10 relative">
+                <!-- Pattern selector + file size slider (side by side) -->
+                <div class="flex flex-col md:flex-row items-start md:items-center gap-4 md:gap-10 flex-1 w-full">
+                    <!-- Pattern selector -->
+                    <div class="w-full md:w-[260px]">
+                        <div class="relative">
+                            <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0 z-10"></div>
+                            <div class="flex relative z-20 border-[3px] border-gray-900 rounded bg-white">
+                                <!-- Pattern type selector -->
+                                <div class="relative flex items-center">
+                                    <select id="pattern_type"
+                                            onchange="changePattern(this)"
+                                            name="pattern_type"
+                                            class="w-21 py-2 pl-2 pr-6 appearance-none bg-[#e6e8eb] focus:outline-none border-r-[3px] border-gray-900">
+                                        <option value="exclude"
+                                                {% if pattern_type == 'exclude' or not pattern_type %}selected{% endif %}>
+                                            Exclude
+                                        </option>
+                                        <option value="include" {% if pattern_type == 'include' %}selected{% endif %}>Include</option>
+                                    </select>
+                                    <svg class="absolute right-2 w-4 h-4 pointer-events-none"
+                                         xmlns="http://www.w3.org/2000/svg"
+                                         viewBox="0 0 24 24"
+                                         fill="none"
+                                         stroke="currentColor"
+                                         stroke-width="2"
+                                         stroke-linecap="round"
+                                         stroke-linejoin="round">
+                                        <polyline points="6 9 12 15 18 9" />
+                                    </svg>
+                                </div>
+                                <!-- Pattern input field -->
+                                <input type="text"
+                                       id="pattern"
+                                       name="pattern"
+                                       placeholder="*.md, src/ "
+                                       value="{{ pattern if pattern else '' }}"
+                                       class=" py-2 px-2 bg-[#E8F0FE] focus:outline-none w-full">
+                            </div>
                         </div>
-                        <input type="text"
-                               id="pattern"
-                               name="pattern"
-                               placeholder="*.md, src/ "
-                               value="{{ pattern if pattern else '' }}"
-                               class=" py-2 px-2 bg-[#E8F0FE] focus:outline-none w-full">
+                    </div>
+                    <!-- File size selector -->
+                    <div class="w-full md:w-[200px]">
+                        <label for="file_size" class="block text-gray-700 mb-1">
+                            Include files under: <span id="size_value" class="font-bold">50kb</span>
+                        </label>
+                        <input type="range"
+                               id="file_size"
+                               name="max_file_size"
+                               min="0"
+                               max="500"
+                               required
+                               value="{{ default_file_size }}"
+                               class="w-full h-3 bg-[#FAFAFA] bg-no-repeat bg-[length:50%_100%] bg-[#ebdbb7] appearance-none border-[3px] border-gray-900 rounded-sm focus:outline-none bg-gradient-to-r from-[#FE4A60] to-[#FE4A60] [&::-webkit-slider-thumb]:w-5 [&::-webkit-slider-thumb]:h-7 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:rounded-sm [&::-webkit-slider-thumb]:cursor-pointer [&::-webkit-slider-thumb]:border-solid [&::-webkit-slider-thumb]:border-[3px] [&::-webkit-slider-thumb]:border-gray-900 [&::-webkit-slider-thumb]:shadow-[3px_3px_0_#000]  ">
+                    </div>
+                </div>
+                <!-- PAT checkbox with PAT field below -->
+                <div class="relative flex flex-col items-start justify-center w-full md:w-64">
+                    <!-- PAT checkbox -->
+                    <div class="flex items-center space-x-2">
+                        <input type="checkbox"
+                               id="showAccessSettings"
+                               class="w-4 h-4 rounded border-gray-900"
+                               onchange="toggleAccessSettings()"
+                               {% if token %}checked{% endif %}>
+                        <label for="showAccessSettings" class="text-gray-900">Private Repository</label>
+                    </div>
+                    <!-- PAT field -->
+                    <div id="accessSettingsContainer"
+                         class="{% if not token %}hidden {% endif %}mt-2 w-full md:absolute md:left-0 md:top-full md:z-30">
+                        <div class="relative w-full">
+                            <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0 z-10"></div>
+                            <div class="flex relative z-20 border-[3px] border-gray-900 rounded bg-white">
+                                <input id="token"
+                                       type="password"
+                                       name="token"
+                                       placeholder="Personal Access Token"
+                                       value="{{ token if token else '' }}"
+                                       class="py-2 px-2 bg-[#E8F0FE] focus:outline-none w-full rounded">
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>
-            <div class="w-[200px] sm:w-[200px] mt-3">
-                <label for="file_size" class="block text-gray-700 mb-1">
-                    Include files under: <span id="size_value" class="font-bold">50kb</span>
-                </label>
-                <input type="range"
-                       id="file_size"
-                       name="max_file_size"
-                       min="0"
-                       max="500"
-                       required
-                       value="{{ default_file_size }}"
-                       class="w-full h-3 bg-[#FAFAFA] bg-no-repeat bg-[length:50%_100%] bg-[#ebdbb7] appearance-none border-[3px] border-gray-900 rounded-sm focus:outline-none bg-gradient-to-r from-[#FE4A60] to-[#FE4A60] [&::-webkit-slider-thumb]:w-5 [&::-webkit-slider-thumb]:h-7 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:rounded-sm [&::-webkit-slider-thumb]:cursor-pointer [&::-webkit-slider-thumb]:border-solid [&::-webkit-slider-thumb]:border-[3px] [&::-webkit-slider-thumb]:border-gray-900 [&::-webkit-slider-thumb]:shadow-[3px_3px_0_#000]  ">
-            </div>
-        </div>
+        </form>
+        <!-- Example repositories section -->
         {% if show_examples %}
-            <!-- Example repositories section -->
             <div class="mt-4">
                 <p class="opacity-70 mb-1">Try these example repositories:</p>
                 <div class="flex flex-wrap gap-2">

--- a/src/server/templates/components/git_form.jinja
+++ b/src/server/templates/components/git_form.jinja
@@ -151,9 +151,13 @@
                                rel="noopener noreferrer"
                                class="text-sm text-gray-600 hover:text-gray-800 flex items-center space-x-1 underline">
                                 <span>Get your token</span>
-                                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" 
-                                          d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path>
+                                <svg class="w-3 h-3"
+                                     fill="none"
+                                     stroke="currentColor"
+                                     viewBox="0 0 24 24"
+                                     xmlns="http://www.w3.org/2000/svg">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14">
+                                    </path>
                                 </svg>
                             </a>
                         </div>

--- a/tests/test_flow_integration.py
+++ b/tests/test_flow_integration.py
@@ -63,6 +63,7 @@ async def test_remote_repository_analysis(request):
         "max_file_size": "243",
         "pattern_type": "exclude",
         "pattern": "",
+        "token": "",
     }
 
     response = client.post("/", data=form_data)
@@ -79,6 +80,7 @@ async def test_invalid_repository_url(request):
         "max_file_size": "243",
         "pattern_type": "exclude",
         "pattern": "",
+        "token": "",
     }
 
     response = client.post("/", data=form_data)
@@ -95,6 +97,7 @@ async def test_large_repository(request):
         "max_file_size": "243",
         "pattern_type": "exclude",
         "pattern": "",
+        "token": "",
     }
 
     response = client.post("/", data=form_data)
@@ -113,6 +116,7 @@ async def test_concurrent_requests(request):
             "max_file_size": "243",
             "pattern_type": "exclude",
             "pattern": "",
+            "token": "",
         }
         response = client.post("/", data=form_data)
         assert response.status_code == 200, f"Request failed: {response.text}"
@@ -133,6 +137,7 @@ async def test_large_file_handling(request):
         "max_file_size": "1",
         "pattern_type": "exclude",
         "pattern": "",
+        "token": "",
     }
 
     response = client.post("/", data=form_data)
@@ -149,6 +154,7 @@ async def test_repository_with_patterns(request):
         "max_file_size": "243",
         "pattern_type": "include",
         "pattern": "*.md",
+        "token": "",
     }
 
     response = client.post("/", data=form_data)

--- a/tests/test_repository_clone.py
+++ b/tests/test_repository_clone.py
@@ -55,7 +55,7 @@ async def test_clone_without_commit() -> None:
     When `clone_repo` is called,
     Then only the clone_repo operation should be performed (no checkout).
     """
-    query = CloneConfig(
+    clone_config = CloneConfig(
         url="https://github.com/user/repo",
         local_path="/tmp/repo",
         commit=None,
@@ -68,9 +68,9 @@ async def test_clone_without_commit() -> None:
             mock_process.communicate.return_value = (b"output", b"error")
             mock_exec.return_value = mock_process
 
-            await clone_repo(query)
+            await clone_repo(clone_config)
 
-            mock_check.assert_called_once_with(query.url, token=None)
+            mock_check.assert_called_once_with(clone_config.url, token=None)
             assert mock_exec.call_count == 1  # Only clone call
 
 
@@ -107,10 +107,10 @@ async def test_clone_nonexistent_repository() -> None:
 )
 async def test_check_repo_exists(mock_stdout: bytes, return_code: int, expected: bool) -> None:
     """
-    Test the `_check_repo_exists` function with different Git HTTP responses.
+    Test the `check_repo_exists` function with different Git HTTP responses.
 
     Given various stdout lines and return codes:
-    When `_check_repo_exists` is called,
+    When `check_repo_exists` is called,
     Then it should correctly indicate whether the repository exists.
     """
     url = "https://github.com/user/repo"
@@ -296,8 +296,8 @@ async def test_clone_specific_branch(tmp_path):
     branch_name = "main"
     local_path = tmp_path / "gitingest"
 
-    config = CloneConfig(url=repo_url, local_path=str(local_path), branch=branch_name)
-    await clone_repo(config)
+    clone_config = CloneConfig(url=repo_url, local_path=str(local_path), branch=branch_name)
+    await clone_repo(clone_config)
 
     # Assertions
     assert local_path.exists(), "The repository was not cloned successfully."
@@ -348,10 +348,7 @@ async def test_clone_creates_parent_directory(tmp_path: Path) -> None:
     Then it should create the parent directories before attempting to clone.
     """
     nested_path = tmp_path / "deep" / "nested" / "path" / "repo"
-    clone_config = CloneConfig(
-        url="https://github.com/user/repo",
-        local_path=str(nested_path),
-    )
+    clone_config = CloneConfig(url="https://github.com/user/repo", local_path=str(nested_path))
 
     with patch("gitingest.cloning.check_repo_exists", return_value=True):
         with patch("gitingest.cloning.run_command", new_callable=AsyncMock) as mock_exec:


### PR DESCRIPTION
## Why

Until now the [gitingest.com](gitingest.com) web UI could ingest only **public** repositories.  
Teams often need to analyse private GitHub repos, so we’re adding a way to supply a personal access token (PAT).

## What’s inside

| Area | Key changes |
|------|-------------|
| **UI** | • New “🔒 Private Repository” checkbox in `git_form.jinja` that reveals a masked PAT field.<br>• Checkbox state + token are posted with the form. |
| **Server routes** | • `index.py`, `dynamic.py`, `query_processor.py` accept `token` from the form and thread it downstream. |
| **Ingestion stack** | • `gitingest.entrypoint.parse_query` and `query_parsing` now carry `token`, letting `try_domains_for_user_and_repo()` resolve bare `user/repo` slugs against GitHub also when a PAT is present. |
| **Tests** | • Added `"token": ""` to `form_data` in `tests/test_flow_integration.py` to keep path-coverage intact. |


**Limitation:** This PR enables PAT-protected cloning **only for GitHub**; other hosts (GitLab, Gitea, etc.) remain public-only for now.