### PR TITLE
Use proper KiB and MiB instead of kilo-/mega- bits

### DIFF
--- a/src/server/templates/components/git_form.jinja
+++ b/src/server/templates/components/git_form.jinja
@@ -107,7 +107,7 @@
                     <!-- File size selector -->
                     <div class="w-full md:w-[200px]">
                         <label for="file_size" class="block text-gray-700 mb-1">
-                            Include files under: <span id="size_value" class="font-bold">50kb</span>
+                            Include files under: <span id="size_value" class="font-bold">50KiB</span>
                         </label>
                         <input type="range"
                                id="file_size"

--- a/src/static/js/utils.js
+++ b/src/static/js/utils.js
@@ -177,11 +177,11 @@ function initializeSlider() {
 }
 
 // Add helper function for formatting size
-function formatSize(sizeInKB) {
-    if (sizeInKB >= 1024) {
-        return Math.round(sizeInKB / 1024) + 'mb';
+function formatSize(sizeInKiB) {
+    if (sizeInKiB >= 1024) {
+        return Math.round(sizeInKiB / 1024) + 'MiB';
     }
-    return Math.round(sizeInKB) + 'kb';
+    return Math.round(sizeInKiB) + 'KiB';
 }
 
 // Initialize slider on page load


### PR DESCRIPTION
kb means "kilobit"
mb is "megabit"

I know many people do not like IEC binary standard prefixes, but if you do not like this change please at least change to `kB` and `MB` (yes, for decimal prefixes k is lower, M is uppercase). Though it would be technically wrong (not ) at least it will properly indicate that units are bytes.

lowercase b for bytes is really confusing and unexpected.