### PR TITLE
fix(ui): use proper decimal prefixes (kB / MB) in file-size selector

### DIFF
--- a/src/server/templates/components/git_form.jinja
+++ b/src/server/templates/components/git_form.jinja
@@ -107,7 +107,7 @@
                     <!-- File size selector -->
                     <div class="w-full md:w-[200px]">
                         <label for="file_size" class="block text-gray-700 mb-1">
-                            Include files under: <span id="size_value" class="font-bold">50kb</span>
+                            Include files under: <span id="size_value" class="font-bold">50kB</span>
                         </label>
                         <input type="range"
                                id="file_size"

--- a/src/static/js/utils.js
+++ b/src/static/js/utils.js
@@ -179,9 +179,9 @@ function initializeSlider() {
 // Add helper function for formatting size
 function formatSize(sizeInKB) {
     if (sizeInKB >= 1024) {
-        return Math.round(sizeInKB / 1024) + 'mb';
+        return Math.round(sizeInKB / 1024) + 'MB';
     }
-    return Math.round(sizeInKB) + 'kb';
+    return Math.round(sizeInKB) + 'kB';
 }
 
 // Initialize slider on page load


### PR DESCRIPTION
**What it does**

* Updates the file-size slider label in `git_form.jinja` and the `formatSize` helper in `utils.js` to show **kB / MB** instead of the misleading **kb / mb**.
* No behaviour or API changes.

**Why**

* Lower-case “b” denotes *bits*. Our UI currently claims kilobits/megabits while the backend logic actually works in *bytes*. This patch fixes that mismatch.

**Discussion**

* We’re standardising on correct decimal prefixes for now. I’m still weighing a full switch to IEC binary prefixes (KiB/MiB) and have asked @cyclotruc for input.

**Thanks**

* Shout-out to @Self-Perfection for catching the issue in https://github.com/cyclotruc/gitingest/pull/293
