### PR TITLE
fix(ui): update directory-picker logic to compute full file paths

### DIFF
--- a/src/server/templates/components/result.jinja
+++ b/src/server/templates/components/result.jinja
@@ -1,22 +1,48 @@
 <script>
-    function getFileName(line) {
-        // Skips "|", "└", "├" found in file tree
-        const index = line.search(/[a-zA-Z0-9]/);
-        return line.substring(index).trim();
+    function getFileName(element) {
+        const indentSize = 4;
+        let path = "";
+        let prevIndentLevel = null;
+
+        while (element) {
+            const line = element.textContent;
+            const index = line.search(/[a-zA-Z0-9_.-]/);
+            const indentLevel = index / indentSize;
+
+            // Stop when we reach or go above the top-level directory
+            if (indentLevel <= 1) {
+                break;
+            }
+
+            // Only include directories that are one level above the previous
+            if (prevIndentLevel === null || indentLevel === prevIndentLevel - 1) {
+                const fileName = line.substring(index).trim();
+                path = fileName + path;
+                prevIndentLevel = indentLevel;
+            }
+
+            element = element.previousElementSibling;
+        }
+
+        return path;
     }
 
     function toggleFile(element) {
         const patternInput = document.getElementById("pattern");
         const patternFiles = patternInput.value ? patternInput.value.split(",").map(item => item.trim()) : [];
 
-        if (element.textContent.includes("Directory structure:")) {
+        const directoryContainer = document.getElementById("directory-structure-container");
+        const treeLineElements = Array.from(directoryContainer.children).filter(child => child.tagName === "PRE");
+
+        // Skip the first two tree lines (header and repository name)
+        if (treeLineElements[0] === element || treeLineElements[1] === element) {
             return;
         }
 
         element.classList.toggle('line-through');
         element.classList.toggle('text-gray-500');
 
-        const fileName = getFileName(element.textContent);
+        const fileName = getFileName(element);
         const fileIndex = patternFiles.indexOf(fileName);
 
         if (fileIndex !== -1) {


### PR DESCRIPTION
## Description

When the user clicks a file or directory in the directory structure tree, the full relative path should be copied into the pattern input field. Currently, clicking on nested files in the tree inserts an incorrect or incomplete path. This pull request addresses that issue.

Closes #288

## Changes

The `getFileName` and `toggleFile` functions in `src/server/templates/components/result.jinja` were modified to correctly compute the full path of a clicked file by traversing DOM elements and extracting its parent directories.

Previously, the regex used to detect the start of the filename was `/[a-zA-Z0-9]/`. It has now been updated to `/[a-zA-Z0-9_.-]/` to correctly handle filenames starting with a dot or underscore (e.g., `.gitignore`, `__init__.py`). An alternative approach could be to match the first character that is not a box-drawing or whitespace character (`"|"`, `"└"`, `"├"`,  `"─"`, `space`).

To determine parent directories, we use the fact that each level of indentation is 4 characters wide. By traversing up the DOM tree from the clicked element and checking for nodes with decreasing indentation levels, we can reconstruct the full relative path.

An early return has been added for clicks on the account and repository name in the directory tree, as this item doesn’t affect the result. Previously, only the header was excluded from interaction.

## Testing

I performed manual testing on a few repositories to confirm that files are correctly excluded after submitting the form. I've attached a screenshot showing the generated file paths.

<img width="474" alt="Screenshot 2025-06-22 at 2 50 42 a m" src="https://github.com/user-attachments/assets/d9bd7045-7899-47e9-9034-55dc73ac7644" />
