### PR TITLE
fix: Add proper test isolation for CLI stdout output test

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -54,21 +54,32 @@ def test_cli_writes_file(tmp_path: Path, monkeypatch: MonkeyPatch, cli_args: Lis
 
 def test_cli_with_stdout_output() -> None:
     """Test CLI invocation with output directed to STDOUT."""
-    result = _invoke_isolated_cli_runner(["./", "--output", "-", "--exclude-pattern", "tests/"])
+    # Clean up any existing digest.txt file before test
+    if os.path.exists(OUTPUT_FILE_NAME):
+        os.remove(OUTPUT_FILE_NAME)
 
-    # ─── core expectations (stdout) ────────────────────────────────────-
-    assert result.exit_code == 0, f"CLI exited with code {result.exit_code}, stderr: {result.stderr}"
-    assert "---" in result.stdout, "Expected file separator '---' not found in STDOUT"
-    assert "src/gitingest/cli.py" in result.stdout, "Expected content (e.g., src/gitingest/cli.py) not found in STDOUT"
-    assert not os.path.exists(OUTPUT_FILE_NAME), f"Output file {OUTPUT_FILE_NAME} was unexpectedly created."
+    try:
+        result = _invoke_isolated_cli_runner(["./", "--output", "-", "--exclude-pattern", "tests/"])
 
-    # ─── the summary must *not* pollute STDOUT, must appear on STDERR ───
-    summary = "Analysis complete! Output sent to stdout."
-    stdout_lines = result.stdout.splitlines()
-    stderr_lines = result.stderr.splitlines()
-    assert summary not in stdout_lines, "Unexpected summary message found in STDOUT"
-    assert summary in stderr_lines, "Expected summary message not found in STDERR"
-    assert f"Output written to: {OUTPUT_FILE_NAME}" not in stderr_lines
+        # ─── core expectations (stdout) ────────────────────────────────────-
+        assert result.exit_code == 0, f"CLI exited with code {result.exit_code}, stderr: {result.stderr}"
+        assert "---" in result.stdout, "Expected file separator '---' not found in STDOUT"
+        assert (
+            "src/gitingest/cli.py" in result.stdout
+        ), "Expected content (e.g., src/gitingest/cli.py) not found in STDOUT"
+        assert not os.path.exists(OUTPUT_FILE_NAME), f"Output file {OUTPUT_FILE_NAME} was unexpectedly created."
+
+        # ─── the summary must *not* pollute STDOUT, must appear on STDERR ───
+        summary = "Analysis complete! Output sent to stdout."
+        stdout_lines = result.stdout.splitlines()
+        stderr_lines = result.stderr.splitlines()
+        assert summary not in stdout_lines, "Unexpected summary message found in STDOUT"
+        assert summary in stderr_lines, "Expected summary message not found in STDERR"
+        assert f"Output written to: {OUTPUT_FILE_NAME}" not in stderr_lines
+    finally:
+        # Clean up any digest.txt file that might have been created during test
+        if os.path.exists(OUTPUT_FILE_NAME):
+            os.remove(OUTPUT_FILE_NAME)
 
 
 def _invoke_isolated_cli_runner(args: List[str]) -> Result:


### PR DESCRIPTION
# Fix: Add proper test isolation for CLI stdout output test

As mentionned in https://github.com/cyclotruc/gitingest/issues/297

## Problem
The `test_cli_with_stdout_output` test was failing intermittently due to leftover `digest.txt` files from previous CLI runs interfering with the test assertions.

## Solution
Added proper test setup and teardown to ensure clean test isolation:
- Clean up any existing `digest.txt` file before running the test
- Wrap test execution in try/finally block to guarantee cleanup after test completion
- Prevents false positives from leftover files affecting test results

## Impact
Ensures reliable test execution and eliminates flaky test failures caused by environment state pollution.

## Files Changed
- `tests/test_cli.py`

## Testing
- ✅ All CLI tests now pass consistently
- ✅ Full test suite (119 tests) passes
- ✅ No regression in existing functionality

---

This fix resolves the failing test by ensuring proper test isolation without changing any core functionality.