### PR TITLE
fix(web UI): "Get your token" link & example repository overlap

### DIFF
--- a/src/server/templates/components/git_form.jinja
+++ b/src/server/templates/components/git_form.jinja
@@ -120,7 +120,7 @@
                     </div>
                 </div>
                 <!-- PAT checkbox with PAT field below -->
-                <div class="relative flex flex-col items-start justify-center w-full md:w-64">
+                <div class="relative flex flex-col items-start justify-center w-full md:w-64 md:ml-4">
                     <!-- PAT checkbox -->
                     <div class="flex items-center space-x-2">
                         <input type="checkbox"


### PR DESCRIPTION
Added a left margin to the checkbox to ensure no overlap on all form factors.

fixes: #301 