### PR TITLE
fix: fix spacing of PAT token section in Git-Form to avoid UI overlap

### DIFF
--- a/src/server/templates/components/git_form.jinja
+++ b/src/server/templates/components/git_form.jinja
@@ -24,7 +24,7 @@
         const row = document.getElementById('controlsRow');
         const show = checkbox.checked;
         container.classList.toggle('hidden', !show);
-        row.classList.toggle('mb-8', show);
+        row.classList.toggle('mb-12', show);
     }
 </script>
 <div class="relative">


### PR DESCRIPTION
The PAT help link was positioned absolutely, which could overlap the example-repository buttons. We now increase the vertical margin from `mb-8` to `mb-12` to the controls row whenever the `Private Repository` checkbox is checked (`toggleAccessSettings`), ensuring enough vertical space while retaining the existing absolute positioning.

Fixes Issue https://github.com/cyclotruc/gitingest/issues/301