### PR TITLE
docs: add links to other language versions of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ You can also replace `hub` with `ingest` in any GitHub URL to access the corresp
 
 [gitingest.com](https://gitingest.com) · [Chrome Extension](https://chromewebstore.google.com/detail/adfjahbijlkjfoicpjkhjicpjpjfaood) · [Firefox Add-on](https://addons.mozilla.org/firefox/addon/gitingest)
 
+<!-- Keep these links. Translations will automatically update with the README. -->
+[Deutsch](https://www.readme-i18n.com/cyclotruc/gitingest?lang=de) | 
+[Español](https://www.readme-i18n.com/cyclotruc/gitingest?lang=es) | 
+[français](https://www.readme-i18n.com/cyclotruc/gitingest?lang=fr) | 
+[日本語](https://www.readme-i18n.com/cyclotruc/gitingest?lang=ja) | 
+[한국어](https://www.readme-i18n.com/cyclotruc/gitingest?lang=ko) | 
+[Português](https://www.readme-i18n.com/cyclotruc/gitingest?lang=pt) | 
+[Русский](https://www.readme-i18n.com/cyclotruc/gitingest?lang=ru) | 
+[中文](https://www.readme-i18n.com/cyclotruc/gitingest?lang=zh)
+
 ## 🚀 Features
 
 - **Easy code context**: Get a text digest from a Git repository URL or a directory

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ You can also replace `hub` with `ingest` in any GitHub URL to access the corresp
 [gitingest.com](https://gitingest.com) · [Chrome Extension](https://chromewebstore.google.com/detail/adfjahbijlkjfoicpjkhjicpjpjfaood) · [Firefox Add-on](https://addons.mozilla.org/firefox/addon/gitingest)
 
 <!-- Keep these links. Translations will automatically update with the README. -->
-[Deutsch](https://www.readme-i18n.com/cyclotruc/gitingest?lang=de) | 
-[Español](https://www.readme-i18n.com/cyclotruc/gitingest?lang=es) | 
-[français](https://www.readme-i18n.com/cyclotruc/gitingest?lang=fr) | 
-[日本語](https://www.readme-i18n.com/cyclotruc/gitingest?lang=ja) | 
-[한국어](https://www.readme-i18n.com/cyclotruc/gitingest?lang=ko) | 
-[Português](https://www.readme-i18n.com/cyclotruc/gitingest?lang=pt) | 
-[Русский](https://www.readme-i18n.com/cyclotruc/gitingest?lang=ru) | 
+[Deutsch](https://www.readme-i18n.com/cyclotruc/gitingest?lang=de) |
+[Español](https://www.readme-i18n.com/cyclotruc/gitingest?lang=es) |
+[Français](https://www.readme-i18n.com/cyclotruc/gitingest?lang=fr) |
+[日本語](https://www.readme-i18n.com/cyclotruc/gitingest?lang=ja) |
+[한국어](https://www.readme-i18n.com/cyclotruc/gitingest?lang=ko) |
+[Português](https://www.readme-i18n.com/cyclotruc/gitingest?lang=pt) |
+[Русский](https://www.readme-i18n.com/cyclotruc/gitingest?lang=ru) |
 [中文](https://www.readme-i18n.com/cyclotruc/gitingest?lang=zh)
 
 ## 🚀 Features


### PR DESCRIPTION
Added language selection links to the `README` for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, Russian, and Chinese.

The updated can be previewed in my forked repository: https://github.com/dowithless/gitingest/tree/patch-1


>readme-i18n is a free tool to translate GitHub README into multiple languages and keep them up to date.
>Replace 'github' with 'readme-i18n' in any GitHub URL to get a localized version of the `README` in your language! 👀