### PR TITLE
refactor: centralize PAT validation, streamline repo checks & misc cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,6 +126,7 @@ celerybeat.pid
 # Environments
 .env
 .venv
+.venv*
 env/
 venv/
 ENV/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,7 +75,7 @@ repos:
         args: ["--disable=line-length"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.0
+    rev: v0.12.1
     hooks:
       - id: ruff-check
       - id: ruff-format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,8 @@ Thanks for your interest in contributing to Gitingest! 🚀 Gitingest aims to be
    cd gitingest
    ```
 
+   **Note**: To contrubute, ensure you have **Python 3.9 or newer** installed, as some of the `pre-commit` hooks (e.g. `pyupgrade`) require Python 3.9+.
+
 3. Set up the development environment and install dependencies:
 
    ```bash
@@ -31,7 +33,7 @@ Thanks for your interest in contributing to Gitingest! 🚀 Gitingest aims to be
 4. Create a new branch for your changes:
 
     ```bash
-    git checkout -b your-branch
+    git checkout -S -b your-branch
     ```
 
 5. Make your changes. Make sure to add corresponding tests for your changes.
@@ -66,10 +68,18 @@ Thanks for your interest in contributing to Gitingest! 🚀 Gitingest aims to be
 
 9. Confirm that everything is working as expected. If you encounter any issues, fix them and repeat steps 6 to 8.
 
-10. Commit your changes:
+10. Commit your changes (signed):
+
+    All commits to Gitingest must be [GPG-signed](https://docs.github.com/en/authentication/managing-commit-signature-verification) so that the project can verify the authorship of every contribution. You can either configure Git globally with:
 
     ```bash
-    git commit -m "Your commit message"
+    git config --global commit.gpgSign true
+    ```
+
+    or pass the `-S` flag as shown below.
+
+    ```bash
+    git commit -S -m "Your commit message"
     ```
 
     If `pre-commit` raises any issues, fix them and repeat steps 6 to 9.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Thanks for your interest in contributing to Gitingest! 🚀 Gitingest aims to be
    cd gitingest
    ```
 
-   **Note**: To contrubute, ensure you have **Python 3.9 or newer** installed, as some of the `pre-commit` hooks (e.g. `pyupgrade`) require Python 3.9+.
+   **Note**: To contribute, ensure you have **Python 3.9 or newer** installed, as some of the `pre-commit` hooks (e.g. `pyupgrade`) require Python 3.9+.
 
 3. Set up the development environment and install dependencies:
 

--- a/src/gitingest/cli.py
+++ b/src/gitingest/cli.py
@@ -131,7 +131,6 @@ async def _async_main(
         If ``True``, also ingest files matched by ``.gitignore`` or ``.gitingestignore`` (default: ``False``).
     token : str | None
         GitHub personal access token (PAT) for accessing private repositories.
-        Can also be set via the ``GITHUB_TOKEN`` environment variable.
     output : str | None
         The path where the output file will be written (default: ``digest.txt`` in current directory).
         Use ``"-"`` to write to ``stdout``.

--- a/src/gitingest/cli.py
+++ b/src/gitingest/cli.py
@@ -131,6 +131,7 @@ async def _async_main(
         If ``True``, also ingest files matched by ``.gitignore`` or ``.gitingestignore`` (default: ``False``).
     token : str | None
         GitHub personal access token (PAT) for accessing private repositories.
+        Can also be set via the ``GITHUB_TOKEN`` environment variable.
     output : str | None
         The path where the output file will be written (default: ``digest.txt`` in current directory).
         Use ``"-"`` to write to ``stdout``.

--- a/src/gitingest/clone.py
+++ b/src/gitingest/clone.py
@@ -13,7 +13,6 @@ from gitingest.utils.git_utils import (
     ensure_git_installed,
     is_github_host,
     run_command,
-    validate_github_token,
 )
 from gitingest.utils.os_utils import ensure_directory
 from gitingest.utils.timeout_wrapper import async_timeout
@@ -23,7 +22,7 @@ if TYPE_CHECKING:
 
 
 @async_timeout(DEFAULT_TIMEOUT)
-async def clone_repo(config: CloneConfig, token: str | None = None) -> None:
+async def clone_repo(config: CloneConfig, *, token: str | None = None) -> None:
     """Clone a repository to a local path based on the provided configuration.
 
     This function handles the process of cloning a Git repository to the local file system.
@@ -36,7 +35,6 @@ async def clone_repo(config: CloneConfig, token: str | None = None) -> None:
         The configuration for cloning the repository.
     token : str | None
         GitHub personal access token (PAT) for accessing private repositories.
-        Can also be set via the ``GITHUB_TOKEN`` environment variable.
 
     Raises
     ------
@@ -50,10 +48,6 @@ async def clone_repo(config: CloneConfig, token: str | None = None) -> None:
     commit: str | None = config.commit
     branch: str | None = config.branch
     partial_clone: bool = config.subpath != "/"
-
-    # Validate token if provided
-    if token and is_github_host(url):
-        validate_github_token(token)
 
     # Create parent directory if it doesn't exist
     await ensure_directory(Path(local_path).parent)

--- a/src/gitingest/query_parser.py
+++ b/src/gitingest/query_parser.py
@@ -313,7 +313,7 @@ async def try_domains_for_user_and_repo(user_name: str, repo_name: str, token: s
     """
     for domain in KNOWN_GIT_HOSTS:
         candidate = f"https://{domain}/{user_name}/{repo_name}"
-        if await check_repo_exists(candidate, token=token if domain == "github.com" else None):
+        if await check_repo_exists(candidate, token=token if domain.startswith("github.") else None):
             return domain
 
     msg = f"Could not find a valid repository host for '{user_name}/{repo_name}'."

--- a/src/gitingest/query_parser.py
+++ b/src/gitingest/query_parser.py
@@ -49,7 +49,6 @@ async def parse_query(
         Patterns to ignore. Can be a set of strings or a single string.
     token : str | None
         GitHub personal access token (PAT) for accessing private repositories.
-        Can also be set via the ``GITHUB_TOKEN`` environment variable.
 
     Returns
     -------
@@ -109,7 +108,6 @@ async def _parse_remote_repo(source: str, token: str | None = None) -> Ingestion
         The URL or domain-less slug to parse.
     token : str | None
         GitHub personal access token (PAT) for accessing private repositories.
-        Can also be set via the ``GITHUB_TOKEN`` environment variable.
 
     Returns
     -------
@@ -301,7 +299,6 @@ async def try_domains_for_user_and_repo(user_name: str, repo_name: str, token: s
         The name of the repository.
     token : str | None
         GitHub personal access token (PAT) for accessing private repositories.
-        Can also be set via the ``GITHUB_TOKEN`` environment variable.
 
     Returns
     -------

--- a/src/gitingest/utils/auth.py
+++ b/src/gitingest/utils/auth.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import os
 
+from gitingest.utils.git_utils import validate_github_token
+
 
 def resolve_token(token: str | None) -> str | None:
     """Resolve the token to use for the query.
@@ -19,4 +21,7 @@ def resolve_token(token: str | None) -> str | None:
         The resolved token.
 
     """
-    return token or os.getenv("GITHUB_TOKEN")
+    token = token or os.getenv("GITHUB_TOKEN")
+    if token:
+        validate_github_token(token)
+    return token

--- a/src/gitingest/utils/compat_typing.py
+++ b/src/gitingest/utils/compat_typing.py
@@ -1,13 +1,13 @@
 """Compatibility layer for typing."""
 
 try:
-    from typing import ParamSpec, TypeAlias  # Py ≥ 3.10
+    from typing import ParamSpec, TypeAlias  # type: ignore[attr-defined]  # Py ≥ 3.10
 except ImportError:
-    from typing_extensions import ParamSpec, TypeAlias  # Py 3.8 / 3.9
+    from typing_extensions import ParamSpec, TypeAlias  # type: ignore[attr-defined]  # Py 3.8 / 3.9
 
 try:
-    from typing import Annotated  # Py ≥ 3.9
+    from typing import Annotated  # type: ignore[attr-defined]  # Py ≥ 3.9
 except ImportError:
-    from typing_extensions import Annotated  # Py 3.8
+    from typing_extensions import Annotated  # type: ignore[attr-defined]  # Py 3.8
 
 __all__ = ["Annotated", "ParamSpec", "TypeAlias"]

--- a/src/gitingest/utils/exceptions.py
+++ b/src/gitingest/utils/exceptions.py
@@ -41,6 +41,9 @@ class InvalidNotebookError(Exception):
 class InvalidGitHubTokenError(ValueError):
     """Exception raised when a GitHub Personal Access Token is malformed."""
 
-    def __init__(self, token: str) -> None:
-        msg = f"Invalid GitHub token format: {token!r}. To generate a token, see https://github.com/settings/tokens."
+    def __init__(self) -> None:
+        msg = (
+            "Invalid GitHub token format. To generate a token, go to "
+            "https://github.com/settings/tokens/new?description=gitingest&scopes=repo."
+        )
         super().__init__(msg)

--- a/src/gitingest/utils/exceptions.py
+++ b/src/gitingest/utils/exceptions.py
@@ -41,8 +41,6 @@ class InvalidNotebookError(Exception):
 class InvalidGitHubTokenError(ValueError):
     """Exception raised when a GitHub Personal Access Token is malformed."""
 
-    def __init__(self) -> None:
-        super().__init__(
-            "Invalid GitHub token format. Token should start with 'github_pat_' or 'ghp_' "
-            "followed by at least 36 characters of letters, numbers, and underscores.",
-        )
+    def __init__(self, token: str) -> None:
+        msg = f"Invalid GitHub token format: {token!r}. To generate a token, see https://github.com/settings/tokens."
+        super().__init__(msg)

--- a/src/gitingest/utils/git_utils.py
+++ b/src/gitingest/utils/git_utils.py
@@ -124,7 +124,7 @@ async def check_repo_exists(url: str, token: str | None = None) -> bool:
         # Public GitHub vs. GitHub Enterprise
         base_api = "https://api.github.com" if host == "github.com" else f"https://{host}/api/v3"
         url = f"{base_api}/repos/{owner}/{repo}"
-        cmd += ["-H", "Accept: application/vnd.github+json", "-H", f"Authorization: Bearer {token}"]
+        cmd += [f"Authorization: Bearer {token}"]
 
     cmd.append(url)
 

--- a/src/gitingest/utils/git_utils.py
+++ b/src/gitingest/utils/git_utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import os
 import re
 from typing import Final
 from urllib.parse import urlparse
@@ -116,7 +117,7 @@ async def check_repo_exists(url: str, token: str | None = None) -> bool:
         "--write-out",
         "%{http_code}",
         "-o",
-        "/dev/null",
+        os.devnull,
     ]
 
     if token and is_github_host(url):

--- a/src/gitingest/utils/ignore_patterns.py
+++ b/src/gitingest/utils/ignore_patterns.py
@@ -93,7 +93,6 @@ DEFAULT_IGNORE_PATTERNS: set[str] = {
     ".svn",
     ".hg",
     ".gitignore",
-    ".gitingestignore",  # Ignore rules specific to Gitingest
     ".gitattributes",
     ".gitmodules",
     # Images and media
@@ -155,7 +154,6 @@ DEFAULT_IGNORE_PATTERNS: set[str] = {
     ## Source maps
     "*.map",
     ## Terraform
-    ".terraform",
     "*.tfstate*",
     ## Dependencies in various languages
     "vendor/",

--- a/tests/test_clone.py
+++ b/tests/test_clone.py
@@ -89,9 +89,9 @@ async def test_clone_nonexistent_repository(repo_exists_true: AsyncMock) -> None
 @pytest.mark.parametrize(
     ("mock_stdout", "return_code", "expected"),
     [
-        (b"HTTP/1.1 200 OK\n", 0, True),  # Existing repo
-        (b"HTTP/1.1 404 Not Found\n", 0, False),  # Non-existing repo
-        (b"HTTP/1.1 200 OK\n", 1, False),  # Failed request
+        (b"200\n", 0, True),  # Existing repo
+        (b"404\n", 0, False),  # Non-existing repo
+        (b"200\n", 1, False),  # Failed request
     ],
 )
 async def test_check_repo_exists(
@@ -209,7 +209,7 @@ async def test_check_repo_exists_with_redirect(mocker: MockerFixture) -> None:
     """
     mock_exec = mocker.patch("asyncio.create_subprocess_exec", new_callable=AsyncMock)
     mock_process = AsyncMock()
-    mock_process.communicate.return_value = (b"HTTP/1.1 302 Found\n", b"")
+    mock_process.communicate.return_value = (b"302\n", b"")
     mock_process.returncode = 0  # Simulate successful request
     mock_exec.return_value = mock_process
 
@@ -228,7 +228,7 @@ async def test_check_repo_exists_with_permanent_redirect(mocker: MockerFixture) 
     """
     mock_exec = mocker.patch("asyncio.create_subprocess_exec", new_callable=AsyncMock)
     mock_process = AsyncMock()
-    mock_process.communicate.return_value = (b"HTTP/1.1 301 Found\n", b"")
+    mock_process.communicate.return_value = (b"301\n", b"")
     mock_process.returncode = 0  # Simulate successful request
     mock_exec.return_value = mock_process
 

--- a/tests/test_git_utils.py
+++ b/tests/test_git_utils.py
@@ -107,17 +107,6 @@ def test_create_git_command(
     assert cmd[len(expected_prefix) :] == expected_suffix
 
 
-def test_create_git_command_invalid_token() -> None:
-    """Test that supplying an invalid token for a GitHub URL raises ``InvalidGitHubTokenError``."""
-    with pytest.raises(InvalidGitHubTokenError):
-        create_git_command(
-            ["git", "clone"],
-            "/some/path",
-            "https://github.com/owner/repo.git",
-            "invalid_token",
-        )
-
-
 @pytest.mark.parametrize(
     "token",
     [
@@ -149,19 +138,16 @@ def test_create_git_command_helper_calls(
     token: str | None,
     should_call: bool,
 ) -> None:
-    """Test that ``validate_github_token`` and ``create_git_auth_header`` are invoked only when appropriate."""
+    """Test that ``create_git_auth_header`` is invoked only when appropriate."""
     work_dir = tmp_path / "repo"
-    validate_mock = mocker.patch("gitingest.utils.git_utils.validate_github_token")
     header_mock = mocker.patch("gitingest.utils.git_utils.create_git_auth_header", return_value="HEADER")
 
     cmd = create_git_command(["git", "clone"], str(work_dir), url, token)
 
     if should_call:
-        validate_mock.assert_called_once_with(token)
         header_mock.assert_called_once_with(token, url=url)
         assert "HEADER" in cmd
     else:
-        validate_mock.assert_not_called()
         header_mock.assert_not_called()
         assert "HEADER" not in cmd
 


### PR DESCRIPTION
#### ✨ Why this PR?

GitHub-PAT handling had drifted into multiple helper layers, making it hard to reason about where a token is verified and who is responsible for failure messages. This PR pushes all validation to the topmost entry points, simplifies remote-repo detection, and performs a round of general housekeeping discovered along the way.

#### 🗂️ What’s inside

| Category             | Details                                                                                                                                                                                                                                                                                     |
| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| **Tooling & docs**   | \* Add `.venv*` to **.gitignore** <br> \* Bump **ruff-pre-commit** → `v0.12.1` <br> \* **CONTRIBUTING.md**: require Python 3.9+, advocate signed (`-S`) commits                                                                                                                             |
| **Token handling**   | \* Create one **source-of-truth** for PAT validation: <br>   `utils.auth.resolve_token` (CLI/library) & `server.query_processor.process_query` (Web UI) <br> \* Broaden `_GITHUB_PAT_PATTERN` and surface invalid token string in `InvalidGitHubTokenError`                                 |
| **Git / networking** | \* Merge `_check_github_repo_exists` into `check_repo_exists` <br> \* switch to `curl --silent --location --write-out %{http_code}` for faster header-only requests <br> \* `create_git_auth_header` now raises `ValueError` on malformed URLs |
| **Code hygiene**     | \* Strip redundant “token can also be set via `GITHUB_TOKEN`” lines from secondary docstrings <br> \* Add `# type: ignore[attr-defined]` hints in `compat_typing.py` for mixed `typing`/`typing_extensions` imports                                                                         |
| **Ignore patterns**  | \* Remove `.gitingestignore` and `.terraform` from `DEFAULT_IGNORE_PATTERNS`                                                                                                                                                     |
| **Tests**            | \* Update HTTP-status expectations (`200`, `301`, `302`, `404`) to new `curl` output <br> \* Remove obsolete `test_create_git_command_invalid_token`                                                                                                                                        |

#### ⚠️ Breaking changes

* **`create_git_command` no longer validates tokens.** Down-stream callers must ensure they pass a valid PAT (use `validate_github_token` or rely on entry-point helpers).
