### PR TITLE
fix: correctly propagate error

### DIFF
--- a/src/server/query_processor.py
+++ b/src/server/query_processor.py
@@ -103,7 +103,7 @@ async def process_query(
             print(f"{Colors.RED}{exc}{Colors.END}")
 
         return IngestErrorResponse(
-            error="Repository not found. Please make sure it is public." if "405" in str(exc) else "",
+            error=str(exc),
             repo_url=short_repo_url,
         )
 


### PR DESCRIPTION
Closes: #355 

# Changes

In the end, it was an issue with the way we propagate the error from the backend.

We had some weird str matching, now we correctly provide the error string.

# Testing

Try to ingest a random url as "xxx" (that's it) and some private repo without token.